### PR TITLE
[BUGFIX] Add the TYPO3 PEAR channel to .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.5
 
 before_script:
+  - pear channel-discover pear.typo3.org
   - pyrus install pear/PHP_CodeSniffer
   - pyrus install typo3/PHPCS_TYPO3_SniffPool-alpha
   - pyrus install typo3/PHPCS_TYPO3v4_Standard-alpha


### PR DESCRIPTION
The PEAR installer asks whether to add the TYPO3 PEAR channel, thus stopping the build. This change adds this channel so that the prompt does not appear anymore.
