### PR TITLE
Preserve @media if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The following selectors are not implemented yet:
 ## Caveats
 
 * Emogrifier requires the HTML and the CSS to be UTF-8. Encodings like ISO8859-1 or ISO8859-15 are not supported.
+* **NEW:** Emogrifier now preserves all valuable @media queries. Media queries can be very useful in
+  responsive email design. See [media query support](https://litmus.com/help/email-clients/media-query-support/).
 * **NEW:** Emogrifier will grab existing inline style attributes _and_ will grab `<style>` blocks from your HTML, but it
   will not grab CSS files referenced in <link> elements (the problem email clients are going to ignore these tags
   anyway, so why leave them in your HTML?).


### PR DESCRIPTION
Fixed #1
- add preserveMediaQuery parameter allow preserve @media query in CSS
- default behavior is same as before (remove all not valuable media query)
- improve regular expression for matching valuable @media query 
- add support for `only` keyword in [media query](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Media_queries?redirectlocale=en-US&redirectslug=CSS%2FMedia_queries)
- add unit tests for this functionality
