### PR TITLE
Ignore all Warnings produce by DOMDocument::loadHTML()

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -408,7 +408,9 @@ class Emogrifier {
         $xmlDocument->encoding = self::ENCODING;
         $xmlDocument->strictErrorChecking = FALSE;
         $xmlDocument->formatOutput = TRUE;
+        libxml_use_internal_errors(TRUE);
         $xmlDocument->loadHTML($this->getUnifiedHtml());
+        libxml_clear_errors();
         $xmlDocument->normalizeDocument();
 
         return $xmlDocument;


### PR DESCRIPTION
Avoid warnings  like Opening and ending tag mismatch... about invalid HTML generated by DOMDocument::loadHTML()
