### PR TITLE
[BUGFIX] Selectors with attribute only

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -508,6 +508,8 @@ class Emogrifier {
                 '/([^\\/]+):first-child/i',
                 // last-child pseudo-selector
                 '/([^\\/]+):last-child/i',
+                // Matches attribute only selector
+                '/^\\[(\\w+)\\]/',
                 // Matches element with attribute
                 '/(\\w)\\[(\\w+)\\]/',
                 // Matches element with EXACT attribute
@@ -519,6 +521,7 @@ class Emogrifier {
                 '//',
                 '*[1]/self::\\1',
                 '*[last()]/self::\\1',
+                '*[@\\1]',
                 '\\1[@\\2]',
                 '\\1[@\\2="\\3"]',
             );

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Emogrifier currently support the following [CSS selectors](http://www.w3.org/TR/
  * adjacent
  * attribute presence
  * attribute value
+ * attribute only
 
 The following selectors are implemented, but currently are broken:
 

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -272,6 +272,20 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase {
     /**
      * @test
      */
+    public function emogrifyCanMatchAttributeOnlySelector() {
+        $html = self::HTML5_DOCUMENT_TYPE . self::LF . '<html><p hidden="hidden"></p></html>' . self::LF;
+        $this->subject->setHtml($html);
+        $this->subject->setCss('[hidden] { color:red; }');
+
+        $this->assertContains(
+            '<p hidden="hidden" style="color:red;">',
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function emogrifyCanAssignStyleRulesFromTwoIdenticalMatchersToElement() {
         $html = self::HTML5_DOCUMENT_TYPE . self::LF . '<html><p></p></html>' . self::LF;
         $this->subject->setHtml($html);


### PR DESCRIPTION
Current version of emogrifier generate invalid xpath //[hidden] instead of //*[@hidden] for attribute only selectors
