### PR TITLE
[BUGFIX] Wrong selector extraction from minified CSS

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -304,7 +304,7 @@ class Emogrifier {
         $cssKey = md5($css);
         if (!isset($this->caches[self::CACHE_KEY_CSS][$cssKey])) {
             // process the CSS file for selectors and definitions
-            preg_match_all('/(?:^|[^{}])\\s*([^{]+){([^}]*)}/mis', $css, $matches, PREG_SET_ORDER);
+            preg_match_all('/(?:^|[\\s^{}]*)([^{]+){([^}]*)}/mis', $css, $matches, PREG_SET_ORDER);
 
             $allSelectors = array();
             foreach ($matches as $key => $selectorString) {

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -489,6 +489,20 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase {
     /**
      * @test
      */
+    public function emogrifyCanMatchMinifiedCss() {
+        $html = self::HTML5_DOCUMENT_TYPE . self::LF . '<html><p></p></html>' . self::LF;
+        $this->subject->setHtml($html);
+        $this->subject->setCss('p{color:blue;}html{color:red;}');
+
+        $this->assertContains(
+            '<html style="color:red;">',
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function emogrifyLowercasesAttributeNamesFromStyleAttributes() {
         $html = self::HTML5_DOCUMENT_TYPE . self::LF . '<html style="COLOR:#ccc;"></html>';
         $this->subject->setHtml($html);


### PR DESCRIPTION
Emogrifier have problem with minified CSS code

First character from first selector is lost:

```
html,h1,.class{color:red;} => tml,h1,.class {color:red;}
```
