### PR TITLE
[BUGFIX] Do not PHP-lint the files in vendor/.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 
 script:
   # Run PHP lint on all PHP files.
-  - find -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+  - find Classes/ Tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
   # Install PHPUNit and run the unit tests.
   - composer install --dev
   - vendor/bin/phpunit Tests/


### PR DESCRIPTION
The PHP lint in .travis.yml checked _all_ PHP files, including those
in vendor/ (which are not our responsibility).

This change switches the lint to only check the files in the Classes/
and Tests/ directories.
