### PR TITLE
[BUGFIX] Escape all backslashes in strings.

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -769,7 +769,7 @@ class Emogrifier {
         $declarations = explode(';', $cssDeclarationBlock);
         foreach ($declarations as $declaration) {
             $matches = array();
-            if (!preg_match('/ *([a-z\-]+) *: *([^;]+) */', $declaration, $matches)) {
+            if (!preg_match('/ *([a-z\\-]+) *: *([^;]+) */', $declaration, $matches)) {
                 continue;
             }
             $propertyName = $matches[1];


### PR DESCRIPTION
The regular expression in parseCssDeclarationBlock contained a single
unescaped backlash. This change escapes that backslash.
