### PR TITLE
[TASK] Add support for PHP 5.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
 
 before_script:
   - composer install --dev


### PR DESCRIPTION
This change adds 5.6 to the build matrix in the Travis configuration.

Resolves #80
