### PR TITLE
Adds mbstring extension to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "1.5.*",


### PR DESCRIPTION
This helps it work on heroku, where mbstring isn't available by default.
