### PR TITLE
[bug][feature] Preserve nonbreaking spaces when preserve encoding is true. Allow encoding type to be set for  multibyte conversion when generating output.

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -17,8 +17,19 @@ class Emogrifier {
     const ENCODING = 'UTF-8';
 
     /**
+     * @var string
+     */
+    const FROM_ENCODING = 'UTF-8';
+
+    /**
+     * @var string
+     */
+
+    const TO_ENCODING = 'HTML-ENTITIES';
+    /**
      * @var integer
      */
+
     const CACHE_KEY_CSS = 0;
 
     /**
@@ -100,6 +111,19 @@ class Emogrifier {
      */
     private $styleAttributesForNodes = array();
 
+
+    /**
+     * @var string
+     */
+    private $fromEncoding = self::FROM_ENCODING;
+
+    /**
+     * @var string
+     */
+    private $toEncoding = self::TO_ENCODING;
+
+
+
     /**
      * This attribute applies to the case where you want to preserve your original text encoding.
      *
@@ -121,9 +145,11 @@ class Emogrifier {
      * @param string $html the HTML to emogrify, must be UTF-8-encoded
      * @param string $css the CSS to merge, must be UTF-8-encoded
      */
-    public function __construct($html = '', $css = '') {
+    public function __construct($html = '', $css = '', $fromEncoding = self::FROM_ENCODING, $toEncoding = self::TO_ENCODING) {
         $this->setHtml($html);
         $this->setCss($css);
+        $this->setFromEncoding($fromEncoding);
+        $this->setToEncoding($toEncoding);
     }
 
     /**
@@ -153,6 +179,40 @@ class Emogrifier {
      */
     public function setCss($css = '') {
         $this->css = $css;
+    }
+
+    /**
+     * If preserveEncoding is true this overrides the default encoding type
+     * to use as the source/original/from when re-encoding.
+     *
+     * This verifies that the encoding type is supported and takes no action
+     * if it is not supported, relying on the default value.
+     * @param string $enc the encoding type to use
+     *
+     * @return void
+     */
+    public function setFromEncoding($enc) {
+        $allowedEncodings = mb_list_encodings();
+        if (!in_array($enc, $allowedEncodings)) {
+            trigger_error('NOTICE: Invalid encoding set for source, used default.', E_USER_NOTICE);
+        }
+        $this->fromEncoding = $enc;
+    }
+
+    /**
+     * If preserveEncoding is true this overrides the default encoding type
+     * to use as the result/output/to when re-encoding.
+     *
+     * @param string $enc the encoding type to use
+     *
+     * @return void
+     */
+    public function setToEncoding($enc) {
+        $allowedEncodings = mb_list_encodings();
+        if (!in_array($enc, $allowedEncodings)) {
+            trigger_error('NOTICE: Invalid encoding set for result, used default.', E_USER_NOTICE);
+        }
+        $this->ToEncoding = $enc;
     }
 
     /**
@@ -355,9 +415,10 @@ class Emogrifier {
         }
 
         $this->copyCssWithMediaToStyleNode($cssParts, $xmlDocument);
-
         if ($this->preserveEncoding) {
-            return mb_convert_encoding($xmlDocument->saveHTML(), self::ENCODING, 'HTML-ENTITIES');
+            $result = str_replace('&nbsp;', '@nbsp;', $xmlDocument->saveHTML());
+            $result = mb_convert_encoding($result, $this->fromEncoding, $this->toEncoding);
+            return str_replace('@nbsp;', '&nbsp;', $result);
         } else {
             return $xmlDocument->saveHTML();
         }
@@ -539,8 +600,7 @@ class Emogrifier {
         } else {
             $bodyWithoutUnprocessableTags = $this->html;
         }
-
-        return mb_convert_encoding($bodyWithoutUnprocessableTags, 'HTML-ENTITIES', self::ENCODING);
+        return mb_convert_encoding($bodyWithoutUnprocessableTags, 'HTML-ENTITIES', 'UTF-8');
     }
 
     /**

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -936,4 +936,79 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase {
         );
     }
 
+    /**
+     * Data Provider
+     * simplified indentation in html 
+     */
+    public function foreignLanguageDataProvider() {
+        return array('Full document with 4 langs' => array(
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><meta charset="utf-8"></head>
+<body>
+<ul>
+<li>One ﻡﺮﺤﺑﺍ، ﻮﻫﺫﺍ ﻩﻭ ﺎﺨﺘﺑﺍﺭ</li>
+<li>Two Esta un una prueba información ¡exclamación! ¿Pregunta?</li>
+<li>Three 你好，这是一个测试</li>
+<li>Four Ciao, Questo è un test</li>
+</ul>
+</body>
+</html>
+'));
+    }
+
+    /**
+     * @test
+     * @dataProvider foreignLanguageDataProvider
+     */
+    public function emogrifyHandlesMultipleLanguages($html) {
+        $this->subject->setHtml($html);
+        $this->assertNotEquals(
+            $html,
+            $this->subject->emogrify(),
+            'default encoding, not preserved encoding'
+        );
+
+        $this->subject->preserveEncoding = TRUE;
+        $this->assertEquals(
+            $html,
+            $this->subject->emogrify(),
+            'default encoding, preserved encoding'
+        );
+        $this->subject->setFromEncoding('UTF-8');
+        $this->subject->setToEncoding('UTF-8');
+        $this->assertEquals(
+            $html,
+            $this->subject->emogrify(),
+            'UTF8 in and out'
+        );
+        $this->subject->setFromEncoding('auto');
+        $this->subject->setToEncoding('auto');
+        $this->assertNotEquals(
+            $html,
+            $this->subject->emogrify(),
+            'auto in and out'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyPreservesNonbreakingSpaces() {
+        $html = '|One Two &nbsp;Three &nbsp;&nbsp;Four &nbsp; &nbsp;|';
+        $preservedEncoding = $html;
+        $this->subject->setHtml($html);
+        $this->assertContains(
+            $preservedEncoding,
+            $this->subject->emogrify()
+        );
+
+        $this->subject->preserveEncoding = TRUE;
+
+        $this->assertContains(
+            $preservedEncoding,
+            $this->subject->emogrify(),
+            'Nonbreak spaces are preserved to force browser to render correctly'
+        );
+    }
 }


### PR DESCRIPTION
Provide setter functions for the encodings used in mb_convert_encoding.  
Allow encoding type to be set in constructor, but rely on default values that used to be hard coded.
Move hard coded encoding values to class constants.
Prevent &nbsp; from being converted to spaces when preserve encoding is true.
Add some unit tests for these changes.
