### PR TITLE
[FEATURE] Add removeDisplayNone option + tests

### DIFF
--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -936,4 +936,44 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase {
         );
     }
 
+    /**
+     * @test
+     */
+    public function emogrifyRemovesDisplayNoneElements() {
+        $css = 'div.foo { display: none; }';
+        $html = self::HTML5_DOCUMENT_TYPE . self::LF .
+            '<html><body><div class="bar"></div><div class="foo"></div></body></html>';
+
+        $expected = '<div class="bar"></div>';
+
+        $this->subject->setHtml($html);
+        $this->subject->setCss($css);
+
+        $this->assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyPreservesDisplayNoneElements() {
+        $css = 'div.foo { display: none; }';
+        $html = self::HTML5_DOCUMENT_TYPE . self::LF .
+            '<html><body><div class="bar"></div><div class="foo"></div></body></html>';
+
+        $expected = '<div class="foo" style="display: none;">';
+
+        $this->subject->setHtml($html);
+        $this->subject->setCss($css);
+        $this->subject->setOptions(array(
+            'removeDisplayNone' => FALSE
+        ));
+
+        $this->assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
 }


### PR DESCRIPTION
This adds an options parameter and some tests for a `removeDisplayNone` option
which specifies if the Emogrifier parser will remove elements with the style
"display: none".

Unfortunatly, that nice little optimization had some consequences.

When writing responsive email templates, "display: none" is used often to hide
certain sections of the template for desktop email clients and show them in
phone clients.

I can see how it'd be nice to clean up elements that will not be displayed in
some cases, so I made it an option.