### PR TITLE
[TASK] Drop support for PHP 5.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "ext-mbstring": "*"
     },
     "require-dev": {


### PR DESCRIPTION
PHP 5.3 had its end of life on August 14th, 2014:
http://php.net/supported-versions.php

So Emogrifier now requires PHP 5.4 or greater.

Closes #79
