### PR TITLE
[TASK] Add a comment about a protected method

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -426,6 +426,10 @@ class Emogrifier {
     /**
      * Adds a style element with $css to $document.
      *
+     * This method is protected to allow overriding.
+     *
+     * @see https://github.com/jjriv/emogrifier/issues/103
+     *
      * @param \DOMDocument $document
      * @param string $css
      *


### PR DESCRIPTION
addStyleElementToDocument is protected instead of private on purpose
in order to allow overrinding in subclasses.

This change adds a comment to provide this information so that it will
stay protected even during code clean-ups.

Closes #122
