### PR TITLE
[BUGFIX] Always use strict comparisons

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -584,7 +584,7 @@ class Emogrifier {
             $search = array('\\#','\\.','');
 
             foreach ($search as $s) {
-                if (trim($selector == '')) {
+                if (trim($selector) === '') {
                     break;
                 }
                 $number = 0;
@@ -734,11 +734,11 @@ class Emogrifier {
     /**
      * @param string[] $match
      *
-     * @return array
+     * @return int[]
      */
     private function parseNth(array $match) {
-        if (in_array(strtolower($match[2]), array('even','odd'))) {
-            $index = strtolower($match[2]) == 'even' ? 0 : 1;
+        if (in_array(strtolower($match[2]), array('even','odd'), TRUE)) {
+            $index = strtolower($match[2]) === 'even' ? 0 : 1;
             return array(self::MULTIPLIER => 2, self::INDEX => $index);
         } elseif (stripos($match[2], 'n') === FALSE) {
             // if there is a multiplier
@@ -753,11 +753,11 @@ class Emogrifier {
                 $index = 0;
             }
 
-            $multiplier = str_ireplace('n', '', $multipleTerm);
+            $multiplier = (int) str_ireplace('n', '', $multipleTerm);
 
             if (!strlen($multiplier)) {
                 $multiplier = 1;
-            } elseif ($multiplier == 0) {
+            } elseif ($multiplier === 0) {
                 return array(self::INDEX => $index);
             } else {
                 $multiplier = intval($multiplier);


### PR DESCRIPTION
- use the "strict" parameter for in_array
- use ===/!== instead of ==/!=
- make sure that parseNth always returns an array of integers
- fix an incorrectly placed parenthesis in getCssSelectorPrecedence

Closes #109
