### PR TITLE
[BUGFIX] Always escape backslashes in strings

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -485,7 +485,7 @@ class Emogrifier {
         $media = '';
 
         $css = preg_replace_callback(
-            '#@media\\s+(?:only\\s)?(?:[\\s{\(]|screen|all)\\s?[^{]+{.*}\\s*}\\s*#misU',
+            '#@media\\s+(?:only\\s)?(?:[\\s{\\(]|screen|all)\\s?[^{]+{.*}\\s*}\\s*#misU',
             function($matches) use (&$media) {
                 $media .= $matches[0];
             }, $css
@@ -609,7 +609,7 @@ class Emogrifier {
      */
     private function translateCssToXpath($paramCssSelector) {
         $cssSelector = ' ' . $paramCssSelector . ' ';
-        $cssSelector = preg_replace_callback('/\s+\w+\s+/',
+        $cssSelector = preg_replace_callback('/\\s+\\w+\\s+/',
             function(array $matches) {
                 return strtolower($matches[0]);
             },
@@ -656,11 +656,11 @@ class Emogrifier {
             // Advanced selectors are going to require a bit more advanced emogrification.
             // When we required PHP 5.3, we could do this with closures.
             $cssSelector = preg_replace_callback(
-                '/([^\\/]+):nth-child\\(\s*(odd|even|[+\-]?\\d|[+\\-]?\\d?n(\\s*[+\\-]\\s*\\d)?)\\s*\\)/i',
+                '/([^\\/]+):nth-child\\(\\s*(odd|even|[+\\-]?\\d|[+\\-]?\\d?n(\\s*[+\\-]\\s*\\d)?)\\s*\\)/i',
                 array($this, 'translateNthChild'), $cssSelector
             );
             $cssSelector = preg_replace_callback(
-                '/([^\\/]+):nth-of-type\\(\s*(odd|even|[+\-]?\\d|[+\\-]?\\d?n(\\s*[+\\-]\\s*\\d)?)\\s*\\)/i',
+                '/([^\\/]+):nth-of-type\\(\s*(odd|even|[+\\-]?\\d|[+\\-]?\\d?n(\\s*[+\\-]\\s*\\d)?)\\s*\\)/i',
                 array($this, 'translateNthOfType'), $cssSelector
             );
 


### PR DESCRIPTION
Backslashes in PHP strings always need to be escaped as two backslashes
(even in regular expressions). There are only two exceptions:
- sequences like \n in double-quoted strings
- escaped single quotes in single-quoted strings (not present in Emogrifier)

Closes #123
