### PR TITLE
[CLEANUP] Drop EmogrifierTest::tearDown

### DIFF
--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -42,15 +42,6 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * Tear down.
-     *
-     * @return void
-     */
-    protected function tearDown() {
-        unset($this->subject);
-    }
-
-    /**
      * @test
      *
      * @expectedException BadMethodCallException


### PR DESCRIPTION
tearDown only contained unset($this->subject). As the unset is not
really necessary for helping the garbage collector, the complete
method can safely be removed.

Closes #131
