### PR TITLE
[BUGFIX] Use a different EmptyStatement Sniff

### DIFF
--- a/Configuration/PhpCodeSniffer/Standards/Emogrifier/ruleset.xml
+++ b/Configuration/PhpCodeSniffer/Standards/Emogrifier/ruleset.xml
@@ -7,6 +7,7 @@
     <rule ref="PSR2"/>
 
     <rule ref="Generic.Classes.DuplicateClassName"/>
+    <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
     <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
     <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
     <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
@@ -43,7 +44,6 @@
     <rule ref="Squiz.Classes.DuplicateProperty"/>
     <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
     <rule ref="Squiz.Classes.SelfMemberReference"/>
-    <rule ref="Squiz.CodeAnalysis.EmptyStatement"/>
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
     <rule ref="Squiz.Commenting.EmptyCatchComment"/>
     <rule ref="Squiz.Commenting.FunctionCommentThrowTag"/>


### PR DESCRIPTION
PHP_CodeSniffer 2.1 has removed the Squiz EmptyStatement Sniff.

This change switches our coding standard to the Generic EmptyStatement Sniff.
