### PR TITLE
[FEATURE] Allow disabling of "inline style" and "style block" parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ After you have set the HTML and CSS, you can call the `emogrify` method to merge
 
     $mergedHtml = $emogrifier->emogrify();
 
+## Options
+
+There are several options that you can set on the Emogrifier object before 
+calling the `emogrify` method:
+
+* `$emogrifier->disableStyleBlocksParsing()` - By default, Emogrifier will grab
+  all `<style>` blocks in the HTML and will apply the CSS styles as inline
+  "style" attributes to the HTML. The `<style>` blocks will then be removed 
+  from the HTML. If you want to disable this functionality so that Emogrifier
+  leaves these `<style>` blocks in the HTML and does not parse them, you should
+  use this option.
+* `$emogrifier->disableInlineStylesParsing()` - By default, Emogrifier
+  preserves all of the "style" attributes on tags in the HTML you pass to it.
+  However if you want to discard all existing inline styles in the HTML before
+  the CSS is applied, you should use this option.
+
 
 ## Installing with Composer
 

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -948,6 +948,79 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function emogrifyWhenDisabledNotAppliesCssFromStyleBlocks()
+    {
+        $styleAttributeValue = 'color: #ccc;';
+        $html = $this->html5DocumentType . self::LF .
+            '<html><style type="text/css">html {' . $styleAttributeValue . '}</style></html>';
+        $this->subject->setHtml($html);
+        $this->subject->disableStyleBlocksParsing();
+
+        $this->assertNotContains(
+            '<html style="' . $styleAttributeValue . '">',
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyWhenStyleBlocksParsingDisabledKeepInlineStyles()
+    {
+        $styleAttributeValue = 'text-align: center;';
+        $html = $this->html5DocumentType . self::LF .
+            '<html><head><style type="text/css">p { color: #ccc; }</style></head>'
+                . '<body><p style="' . $styleAttributeValue . '">paragraph</p></body></html>';
+        $expected = '<p style="' . $styleAttributeValue . '">';
+        $this->subject->setHtml($html);
+        $this->subject->disableStyleBlocksParsing();
+
+        $this->assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyWhenDisabledNotAppliesCssFromInlineStyles()
+    {
+        $styleAttributeValue = 'color: #ccc;';
+        $html = $this->html5DocumentType . self::LF .
+            '<html style="' . $styleAttributeValue . '"></html>';
+        $expected = '<html></html>';
+        $this->subject->setHtml($html);
+        $this->subject->disableInlineStyleAttributesParsing();
+
+        $this->assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyWhenInlineStyleAttributesParsingDisabledKeepStyleBlockStyles()
+    {
+        $styleAttributeValue = 'color: #ccc;';
+        $html = $this->html5DocumentType . self::LF .
+            '<html><head><style type="text/css">p { ' . $styleAttributeValue . ' }</style></head>'
+                . '<body><p style="text-align: center;">paragraph</p></body></html>';
+        $expected = '<p style="' . $styleAttributeValue . '">';
+        $this->subject->setHtml($html);
+        $this->subject->disableInlineStyleAttributesParsing();
+
+        $this->assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function emogrifyAppliesCssWithUpperCaseSelector()
     {
         $html = $this->html5DocumentType . self::LF .


### PR DESCRIPTION
This pull request implements the functionality described in task #155.

Please review how I edited the `emogrify()` method to disable "inline style" parsing to ensure it was done properly.

I updated the readme and added unit tests to cover the new options that were added.

Once you merge in this pull request, would you mind tagging a 0.1.1 release?