### PR TITLE
[FEATURE] Added enablePreserveEncoding option

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -9,6 +9,7 @@ namespace Pelago;
  * @author Cameron Brooks
  * @author Jaime Prado
  * @author Roman Ožana <ozana@omdesign.cz>
+ * @author Erik Pall Hansen
  */
 class Emogrifier
 {
@@ -335,6 +336,16 @@ class Emogrifier
     public function disableStyleBlocksParsing()
     {
         $this->isStyleBlocksParsingEnabled = false;
+    }
+
+    /**
+     * Enables the preservation of encoding
+     *
+     * return @void
+     */
+    public function enablePreserveEncoding()
+    {
+        $this->preserveEncoding = true;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ styles into inline style attributes in your HTML code.
 - [Usage](#usage)
 - [Installing with Composer](#installing-with-composer)
 - [Usage](#usage)
+- [Options](#options)
 - [Supported CSS selectors](#supported-css-selectors)
 - [Caveats](#caveats)
 - [Maintainer](#maintainer)
@@ -78,6 +79,16 @@ calling the `emogrify` method:
   preserves all of the "style" attributes on tags in the HTML you pass to it.
   However if you want to discard all existing inline styles in the HTML before
   the CSS is applied, you should use this option.
+* `$emogrifier->enablePreserveEncoding()` - By default, Emogrifier translates 
+  your text into HTML entities for two reasons: 
+  
+  * Because of client incompatibilities, it is better practice to send out HTML
+    entities.
+  
+  * It translates any illegal XML characters that DOMDocument cannot work with.
+  
+  If you would like to preserve your original encoding, you should use this 
+  option.
 
 
 ## Installing with Composer

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -90,7 +90,24 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function emogrifyCanKeepEncodedUmlauts()
+    public function emogrifyCanKeepEncodedUmlautsUsingMethod()
+    {
+        $this->subject->enablePreserveEncoding();
+        $encodedString = 'Küss die Hand, schöne Frau.';
+
+        $html = $this->html5DocumentType . '<html><p>' . $encodedString . '</p></html>';
+        $this->subject->setHtml($html);
+
+        $this->assertContains(
+            $encodedString,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyCanKeepEncodedUmlautsUsingProperty()
     {
         $this->subject->preserveEncoding = true;
         $encodedString = 'Küss die Hand, schöne Frau.';


### PR DESCRIPTION
This `task/method-for-preserving-encoding` branch branches off of the `task/disable-style-parsing branch`, as it is a direct response to the methods that were added in that branch. Please merge in the pull request for that branch (#156) in order to see the diff of what this branches adds. Or, you can simply look at a diff between the two branches: https://github.com/classyllama/emogrifier/compare/task/disable-style-parsing...classyllama:task/method-for-preserving-encoding

Here is an explanation of the changes:

The public `preserveEncoding` property already existed, but since the
`isInlineStylesParsingEnabled and `isStyleBlocksParsingEnabled` methods
were recently added, I thought it made sense for all options to be set via
methods, rather than a mix of methods + properties.

A case could be made for changing the `preserveEncoding` method to a private
method, but it would break backwards compatibility. So maybe stick this in
as a TODO for a minor version.

Since the preservation of encoding can be enabled via either the method or
the property, I updated the unit tests to account for both options.

Updated documentation to reflect the usage of this method.