### PR TITLE
[FEATURE] Add isRemoveDisplayNoneEnabled option + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ After you have set the HTML and CSS, you can call the `emogrify` method to merge
 
 ## Options
 
-There are several options that you can set on the Emogrifier object before 
+There are several options that you can set on the Emogrifier object before
 calling the `emogrify` method:
 
 * `$emogrifier->disableStyleBlocksParsing()` - By default, Emogrifier will grab
   all `<style>` blocks in the HTML and will apply the CSS styles as inline
-  "style" attributes to the HTML. The `<style>` blocks will then be removed 
+  "style" attributes to the HTML. The `<style>` blocks will then be removed
   from the HTML. If you want to disable this functionality so that Emogrifier
   leaves these `<style>` blocks in the HTML and does not parse them, you should
   use this option.
@@ -78,6 +78,9 @@ calling the `emogrify` method:
   preserves all of the "style" attributes on tags in the HTML you pass to it.
   However if you want to discard all existing inline styles in the HTML before
   the CSS is applied, you should use this option.
+* `$emogrifier->disableInvisibleNodeRemoval()` - By default, Emogrifier removes
+  elements from the DOM that have the style attribute `display: none;`.  If
+  you would like to keep invisible elements in the DOM, use this option.
 
 
 ## Installing with Composer
@@ -163,18 +166,18 @@ Those that wish to contribute bug fixes, new features, refactorings and clean-up
 When you contribute, please take the following things into account:
 
 * Please cover all changes with unit tests and make sure that your code does not break any existing tests.
-* To run the existing PHPUnit tests, run the following 
+* To run the existing PHPUnit tests, run the following
   command:
-  
+
       composer install
-  
+
   and then run this command:
-  
+
       vendor/bin/phpunit Tests/
-  
-  If you want to uninstall the development packages that were installed when 
+
+  If you want to uninstall the development packages that were installed when
   you ran `composer install`, you can run this command:
-  
+
       composer install --no-dev
 * Please use the same coding style (PSR-2) as the rest of the code. Indentation is four spaces.
 * Please make your code clean, well-readable and easy to understand.

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1090,4 +1090,64 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             $this->subject->emogrify()
         );
     }
+
+    /**
+     * @test
+     */
+    public function emogrifyByDefaultRemovesElementsWithDisplayNoneFromExternalCss()
+    {
+        $css = 'div.foo { display: none; }';
+        $html = $this->html5DocumentType . self::LF .
+            '<html><body><div class="bar"></div><div class="foo"></div></body></html>';
+
+        $expected = '<div class="bar"></div>';
+
+        $this->subject->setHtml($html);
+        $this->subject->setCss($css);
+
+        $this->assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyByDefaultRemovesElementsWithDisplayNoneInStyleAttribute()
+    {
+        $html = $this->html5DocumentType . self::LF .
+            '<html><body><div class="bar"></div><div class="foobar" style="display: none;"></div>'
+                . '</body></html>';
+
+        $expected = '<div class="bar"></div>';
+
+        $this->subject->setHtml($html);
+
+        $this->assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyAfterDisableInvisibleNodeRemovalPreservesInvisibleElements()
+    {
+        $css = 'div.foo { display: none; }';
+        $html = $this->html5DocumentType . self::LF .
+            '<html><body><div class="bar"></div><div class="foo"></div></body></html>';
+
+        $expected = '<div class="foo" style="display: none;">';
+
+        $this->subject->setHtml($html);
+        $this->subject->setCss($css);
+        $this->subject->disableInvisibleNodeRemoval();
+
+        $this->assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
 }


### PR DESCRIPTION
This adds an options parameter and some tests for a `isRemoveDisplayNoneEnabled` option
which specifies if the Emogrifier parser will remove elements with the style
"display: none".

Unfortunatly, the nice little optimization has some consiquences.

When writing responsive email templates, "display: none" is used often to hide
certain sections of the template for desktop email clients and show them in
phone clients.

I can see how it'd be nice to clean up elements that will not be displayed in
some cases, so that's why I made it an options field.
