### PR TITLE
[BUGFIX] Avoid GitHub authentication failures on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ php:
   - hhvm
 
 before_script:
-  - composer install
+  - composer install --no-interaction
   - vendor/bin/phpcs --config-set encoding utf-8
 
 script:


### PR DESCRIPTION
By providing the --no-interaction option for composer install,
composer will do a git clone if the API limit is exhausted.

Fixes: #90