### PR TITLE
[TASK] Document the way Emogrifier handles XHTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,14 @@ The following selectors are not implemented yet:
 * All CSS attributes that apply to a node will be applied, even if they are redundant. For example, if you define a
   font attribute _and_ a font-size attribute, both attributes will be applied to that node (in other words, the more
   specific attribute will not be combined into the more general attribute).
-* There's a good chance you might encounter problems if your HTML is not well formed and valid (DOMDocument might
-  complain). If you get problems like this, consider running your HTML through [Tidy](http://php.net/manual/en/book.tidy.php)
-  before you pass it to Emogrifier.
+* There's a good chance you might encounter problems if your HTML is not
+  well-formed and valid (DOMDocument might complain). If you get problems like
+  this, consider running your HTML through
+  [Tidy](http://php.net/manual/en/book.tidy.php) before you pass it to
+  Emogrifier.
+* Emogrifier automatically converts the provided (X)HTML into HTML, i.e.,
+  self-closing tags will lose their slash. To keep your HTML valid, it is
+  recommended to use HTML5 instead of one of the XHTML variants.
 * Finally, Emogrifier only supports CSS1 level selectors and a few CSS2 level selectors (but not all of them). It
   does not support pseudo selectors (Emogrifier works by converting CSS selectors to XPath selectors, and pseudo
   selectors cannot be converted accurately).

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1151,4 +1151,52 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             $this->subject->emogrify()
         );
     }
+
+    /**
+     * @test
+     */
+    public function emogrifyForXhtmlDocumentTypeConvertsXmlSelfClosingTagsToNonXmlSelfClosingTag() {
+        $this->subject->setHtml($this->xhtml1StrictDocumentType . '<html><body><br/></body></html>');
+
+        self::assertContains(
+            '<body><br></body>',
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyForHtml5DocumentTypeKeepsNonXmlSelfClosingTagsAsNonXmlSelfClosing() {
+        $this->subject->setHtml($this->html5DocumentType . '<html><body><br></body></html>');
+
+        self::assertContains(
+            '<body><br></body>',
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyForHtml5DocumentTypeConvertXmlSelfClosingTagsToNonXmlSelfClosingTag() {
+        $this->subject->setHtml($this->html5DocumentType . '<html><body><br/></body></html>');
+
+        self::assertContains(
+            '<body><br></body>',
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyAutomaticallyClosesUnclosedTag() {
+        $this->subject->setHtml($this->html5DocumentType . '<html><body><p></body></html>');
+
+        self::assertContains(
+            '<body><p></p></body>',
+            $this->subject->emogrify()
+        );
+    }
 }


### PR DESCRIPTION
Emogrifiert always converts XHTML to HTML. This now is documented in the
README and in the unit tests.

Fixes #153