### PR TITLE
Properly handle UTF-8 characters and entities

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -15,11 +15,6 @@ namespace Pelago;
 class Emogrifier
 {
     /**
-     * @var string
-     */
-    const ENCODING = 'UTF-8';
-
-    /**
      * @var int
      */
     const CACHE_KEY_CSS = 0;
@@ -130,6 +125,13 @@ class Emogrifier
      * @var bool
      */
     private $shouldKeepInvisibleNodes = true;
+
+    /**
+     * Determines whether Content-Type meta tag with UTF-( charset should be inserted to HTML if it is missing
+     *
+     * @var bool
+     */
+    private $shouldFixMissingCharsetDeclaration = true;
 
     /**
      * The constructor.
@@ -320,6 +322,16 @@ class Emogrifier
     public function disableInvisibleNodeRemoval()
     {
         $this->shouldKeepInvisibleNodes = false;
+    }
+
+    /**
+     * Disables the removal of elements with `display: none` properties.
+     *
+     * @return void
+     */
+    public function disableCharsetFix()
+    {
+        $this->shouldFixMissingCharsetDeclaration = false;
     }
 
     /**
@@ -649,7 +661,6 @@ class Emogrifier
     private function createXmlDocument()
     {
         $xmlDocument = new \DOMDocument;
-        $xmlDocument->encoding = self::ENCODING;
         $xmlDocument->strictErrorChecking = false;
         $xmlDocument->formatOutput = true;
         $libXmlState = libxml_use_internal_errors(true);
@@ -662,7 +673,8 @@ class Emogrifier
     }
 
     /**
-     * Returns the HTML with the unprocessable HTML tags removed.
+     * Returns the HTML with the unprocessable HTML tags removed and
+     * with added Content-Type meta tag if needed.
      *
      * @return string the unified HTML
      *
@@ -679,6 +691,20 @@ class Emogrifier
             );
         } else {
             $bodyWithoutUnprocessableTags = $this->html;
+        }
+        
+        if ($this->shouldFixMissingCharsetDeclaration) {
+            if (!stristr($bodyWithoutUnprocessableTags, 'Content-Type')) {
+
+                // We are trying to insert the meta tag to the right spot in the DOM as if we just prepend it to the HTML we will lose attributes set to the HTML tag.
+                if (stristr($bodyWithoutUnprocessableTags, '<head')) {
+                    $bodyWithoutUnprocessableTags = preg_replace('/<head(.*?)>/i', '<head$1><meta http-equiv="Content-Type" content="text/html; charset=utf-8">', $bodyWithoutUnprocessableTags);
+                } elseif (stristr($bodyWithoutUnprocessableTags, '<html')) {
+                    $bodyWithoutUnprocessableTags = preg_replace('/<html(.*?)>/i', '<html$1><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>', $bodyWithoutUnprocessableTags);
+                } else {
+                    $bodyWithoutUnprocessableTags = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $bodyWithoutUnprocessableTags;
+                }
+            }
         }
 
         return $bodyWithoutUnprocessableTags;

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -289,7 +289,7 @@ class Emogrifier
 
         $this->copyCssWithMediaToStyleNode($cssParts, $xmlDocument);
 
-        return mb_convert_encoding($xmlDocument->saveHTML(), self::ENCODING, 'HTML-ENTITIES');
+        return $xmlDocument->saveHTML();
     }
 
     /**
@@ -662,8 +662,7 @@ class Emogrifier
     }
 
     /**
-     * Returns the HTML with the non-ASCII characters converts into HTML entities and the unprocessable
-     * HTML tags removed.
+     * Returns the HTML with the unprocessable HTML tags removed.
      *
      * @return string the unified HTML
      *
@@ -682,7 +681,7 @@ class Emogrifier
             $bodyWithoutUnprocessableTags = $this->html;
         }
 
-        return mb_convert_encoding($bodyWithoutUnprocessableTags, 'HTML-ENTITIES', self::ENCODING);
+        return $bodyWithoutUnprocessableTags;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ After you have set the HTML and CSS, you can call the `emogrify` method to merge
 
     $mergedHtml = $emogrifier->emogrify();
 
-NB! for Emogrifier to properly deal with entities and UTF-8 characters you need to add Content-Type meta tag with UTF-8 charset declaration to your HTML.
+For Emogrifier to properly deal with entities and UTF-8 characters you need to add Content-Type meta tag with UTF-8 charset
+declaration to your HTML. If you don't provide this tag in your HTML then Emogrifier adds it automatically.
 
     $html = '<html><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><h1>Hello world!</h1></html>';
 
@@ -85,6 +86,9 @@ calling the `emogrify` method:
 * `$emogrifier->disableInvisibleNodeRemoval()` - By default, Emogrifier removes
   elements from the DOM that have the style attribute `display: none;`.  If
   you would like to keep invisible elements in the DOM, use this option.
+* `$emogrifier->disableCharsetFix()` - By default, Emogrifier fixes HTML with
+  missing Content-Type meta tag by inserting the tag with UTF-8 charset declaration
+  to the document. You can disable this functionality if you would like to.
 
 
 ## Installing with Composer

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ After you have set the HTML and CSS, you can call the `emogrify` method to merge
 
     $mergedHtml = $emogrifier->emogrify();
 
+NB! for Emogrifier to properly deal with entities and UTF-8 characters you need to add Content-Type meta tag with UTF-8 charset declaration to your HTML.
+
+    $html = '<html><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><h1>Hello world!</h1></html>';
+
 ## Options
 
 There are several options that you can set on the Emogrifier object before

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -114,7 +114,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
         $html = $this->xhtml1StrictDocumentType . '<html style="padding: 1px;"><p>' . $umlautString . '</p></html>';
         $this->subject->setHtml($html);
-echo($this->subject->emogrify());
+
         $this->assertContains(
             $umlautString,
             $this->subject->emogrify()

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -96,7 +96,39 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         $umlautString = 'Küss die Hand, schöne Frau.';
 
-        $html = $this->html5DocumentType . '<html><p>' . $umlautString . '</p></html>';
+        $html = $this->html5DocumentType . '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><p>' . $umlautString . '</p></html>';
+        $this->subject->setHtml($html);
+
+        $this->assertContains(
+            $umlautString,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyKeepsUtf8UmlautsXhtml()
+    {
+        $umlautString = 'Öösel läks õunu täis ämber uhkelt ümber.';
+
+        $html = $this->xhtml1StrictDocumentType . '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><p>' . $umlautString . '</p></html>';
+        $this->subject->setHtml($html);
+
+        $this->assertContains(
+            $umlautString,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyKeepsUtf8UmlautsHtml4()
+    {
+        $umlautString = 'Öösel läks õunu täis ämber uhkelt ümber.';
+
+        $html = $this->html4TransitionalDocumentType . '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><p>' . $umlautString . '</p></html>';
         $this->subject->setHtml($html);
 
         $this->assertContains(

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -96,7 +96,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         $umlautString = 'Küss die Hand, schöne Frau.';
 
-        $html = $this->html5DocumentType . '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><p>' . $umlautString . '</p></html>';
+        $html = $this->html5DocumentType . '<html><p>' . $umlautString . '</p></html>';
         $this->subject->setHtml($html);
 
         $this->assertContains(
@@ -108,13 +108,13 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function emogrifyKeepsUtf8UmlautsXhtml()
+    public function emogrifyKeepsUtf8UmlautsInXhtml()
     {
-        $umlautString = 'Öösel läks õunu täis ämber uhkelt ümber.';
+        $umlautString = 'Öösel läks õunu täis ämber uhkelt ümber. Also ampersand entity should remain unchanged: &amp;';
 
-        $html = $this->xhtml1StrictDocumentType . '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><p>' . $umlautString . '</p></html>';
+        $html = $this->xhtml1StrictDocumentType . '<html style="padding: 1px;"><p>' . $umlautString . '</p></html>';
         $this->subject->setHtml($html);
-
+echo($this->subject->emogrify());
         $this->assertContains(
             $umlautString,
             $this->subject->emogrify()
@@ -124,11 +124,11 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function emogrifyKeepsUtf8UmlautsHtml4()
+    public function emogrifyKeepsUtf8UmlautsInHtml4()
     {
-        $umlautString = 'Öösel läks õunu täis ämber uhkelt ümber.';
+        $umlautString = 'Öösel läks õunu täis ämber uhkelt ümber. Also ampersand entity should remain unchanged: &amp;';
 
-        $html = $this->html4TransitionalDocumentType . '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><p>' . $umlautString . '</p></html>';
+        $html = $this->html4TransitionalDocumentType . '<html><p>' . $umlautString . '</p></html>';
         $this->subject->setHtml($html);
 
         $this->assertContains(
@@ -142,7 +142,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyForHtmlTagOnlyAndEmptyCssReturnsHtmlTagWithHtml4DocumentType()
     {
-        $html = '<html></html>';
+        $html = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head></html>';
         $this->subject->setHtml($html);
         $this->subject->setCss('');
 
@@ -157,7 +157,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyForHtmlTagWithXhtml1StrictDocumentTypeKeepsDocumentType()
     {
-        $html = $this->xhtml1StrictDocumentType . self::LF . '<html></html>' . self::LF;
+        $html = $this->xhtml1StrictDocumentType . self::LF . '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head></html>' . self::LF;
         $this->subject->setHtml($html);
         $this->subject->setCss('');
 
@@ -172,7 +172,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyForHtmlTagWithXhtml5DocumentTypeKeepsDocumentType()
     {
-        $html = $this->html5DocumentType . self::LF . '<html></html>' . self::LF;
+        $html = $this->html5DocumentType . self::LF . '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head></html>' . self::LF;
         $this->subject->setHtml($html);
         $this->subject->setCss('');
 
@@ -1022,7 +1022,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $styleAttributeValue = 'color: #ccc;';
         $html = $this->html5DocumentType . self::LF .
             '<html style="' . $styleAttributeValue . '"></html>';
-        $expected = '<html></html>';
+        $expected = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head></html>';
         $this->subject->setHtml($html);
         $this->subject->disableInlineStyleAttributesParsing();
 


### PR DESCRIPTION
This pull request will make handling of character entities work properly. As this is something that is dependant on PHPs DOMDocument then basically all that you can do is to add a note in the documentation that input (X)HTML needs to include meta tag with UTF-8 as charset. Otherwise DOMDocument will re-encode all the entities and characters in the document.

I removed the workaround put in to the code as it only made things worse. Added some test cases and added a note to README.md

Partially connected to #172