### PR TITLE
Fix CSS selectors with exact attribute only

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -767,7 +767,7 @@ class Emogrifier
                 // last-child pseudo-selector
                 '/([^\\/]+):last-child/i',
                 // Matches attribute only selector
-                '/^\\[(\\w+)\\]/',
+                '/^\\[(\\w+|\\w+\\=[\'"]?\\w+[\'"]?)\\]/',
                 // Matches element with attribute
                 '/(\\w)\\[(\\w+)\\]/',
                 // Matches element with EXACT attribute

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -371,6 +371,9 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
                 => array('span[title] {' . $styleRule . '} ', '#<span title="bonjour" ' . $styleAttribute . '>#'),
             'attribute presence selector SPAN[title] not matches element without any attributes'
                 => array('span[title] {' . $styleRule . '} ', '#<span>#'),
+            'attribute value selector [role="button"] matches element with matching attribute value' => array(
+                '[id="html"] {' . $styleRule . '} ', '#<html id="html" ' . $styleAttribute . '>#'
+	          ),
             'attribute value selector SPAN[title] matches element with matching attribute value' => array(
                 'span[title="bonjour"] {' . $styleRule . '} ', '#<span title="bonjour" ' . $styleAttribute . '>#'
             ),


### PR DESCRIPTION
CSS selectors like `[role="button"] { }` generate warnings like

`Warning: DOMXPath::query(): Invalid expression pelago/emogrifier/Classes/Emogrifier.php on line 269`

Selectors without tag are valid and sometimes used in code e.g. [Twitter Boostrap](https://github.com/twbs/bootstrap/blob/master/less/scaffolding.less#L159)