### PR TITLE
Ignore invalid selectors, see #179

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -261,6 +261,10 @@ class Emogrifier
         foreach ($this->caches[self::CACHE_KEY_CSS][$cssKey] as $value) {
             // query the body for the xpath selector
             $nodesMatchingCssSelectors = $xpath->query($this->translateCssToXpath($value['selector']));
+            // Ignore invalid selectors
+            if (false === $nodesMatchingCssSelectors) {
+                continue;
+            }
 
             /** @var \DOMElement $node */
             foreach ($nodesMatchingCssSelectors as $node) {

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -621,6 +621,29 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     */
+    public function emogrifyIgnoreInvalidSelectors()
+    {
+        $html = $this->html5DocumentType . self::LF . '<html><style type="text/css">p{color:red;} <style data-x="1">html{cursor:text;}</style></html>';
+        $this->subject->setHtml($html);
+        $noerrors = true;
+        set_error_handler(function($errno, $errstr) use (&$noerrors) {
+            if ($errstr == 'DOMXPath::query(): Invalid expression') {
+                //Eat this error, see #179
+                return true;
+            }
+            $noerrors = false;
+            return true;
+        });
+        $this->subject->emogrify();
+        restore_error_handler();
+        self::assertTrue(
+            $noerrors
+        );
+    }
+
+    /**
      * Data provider for things that should be left out when applying the CSS.
      *
      * @return array[]


### PR DESCRIPTION
This is a partial fix for #179. It simply adds a check on the xpath query return value before attempting to iterate over the result set. If the xpath has failed, it just issues a continue to go to the next iteration.

This fixes the second of the two errors mentioned in the ticket, so it's effectively treating the symptom rather than the cause, but it's better than nothing! I don't know how it would be best to try to prevent the first error - somehow validate the CSS selector fragment before trying to pass it to the xpath converter?