### PR TITLE
Handle important

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -438,17 +438,17 @@ class Emogrifier
         }
     }
 
-     /**
-      * This removes styles from your email that contain display:none.
-      * We need to look for display:none, but we need to do a case-insensitive search. Since DOMDocument only
-      * supports XPath 1.0, lower-case() isn't available to us. We've thus far only set attributes to lowercase,
-      * not attribute values. Consequently, we need to translate() the letters that would be in 'NONE' ("NOE")
-      * to lowercase.
-      *
-      * @param \DOMXPath $xpath
-      *
-      * @return void
-      */
+    /**
+     * This removes styles from your email that contain display:none.
+     * We need to look for display:none, but we need to do a case-insensitive search. Since DOMDocument only
+     * supports XPath 1.0, lower-case() isn't available to us. We've thus far only set attributes to lowercase,
+     * not attribute values. Consequently, we need to translate() the letters that would be in 'NONE' ("NOE")
+     * to lowercase.
+     *
+     * @param \DOMXPath $xpath
+     *
+     * @return void
+     */
     private function removeInvisibleNodes(\DOMXPath $xpath)
     {
         $nodesWithStyleDisplayNone = $xpath->query(
@@ -530,6 +530,13 @@ class Emogrifier
     private function generateStyleStringFromDeclarationsArrays(array $oldStyles, array $newStyles)
     {
         $combinedStyles = array_merge($oldStyles, $newStyles);
+
+        foreach ($oldStyles as $attribute => $expression) {
+            if (isset($newStyles[$attribute]) && strtolower(substr($expression, -10)) === '!important') {
+                $combinedStyles[$attribute] = $expression;
+            }
+        }
+
         $style = '';
         foreach ($combinedStyles as $attributeName => $attributeValue) {
             $style .= (strtolower(trim($attributeName)) . ': ' . trim($attributeValue) . '; ');

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1519,4 +1519,77 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             $this->subject->emogrify()
         );
     }
+
+    /**
+     * @test
+     */
+    public function emogrifyHandleNoImportant()
+    {
+        $css = 'p { margin: 1px; padding: 1px;}';
+        $html = $this->html5DocumentType . self::LF .
+            '<html><head</head><body><p style="margin: 2px; text-align: center;">some content</p></body></html>';
+        $expected = '<p style="margin: 2px; text-align: center; padding: 1px;">';
+        $this->subject->setHtml($html);
+        $this->subject->setCss($css);
+
+        self::assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyHandleImportantStyleTag()
+    {
+        $css = 'p { margin: 1px !important; padding: 1px;}';
+        $html = $this->html5DocumentType . self::LF .
+            '<html><head</head><body><p style="margin: 2px; text-align: center;">some content</p></body></html>';
+        $expected = '<p style="margin: 1px !important; text-align: center; padding: 1px;">';
+        $this->subject->setHtml($html);
+        $this->subject->setCss($css);
+
+        self::assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyHandleImportantStyleTagCaseInsensitive()
+    {
+        $css = 'p { margin: 1px !ImPorTant; padding: 1px;}';
+        $html = $this->html5DocumentType . self::LF .
+            '<html><head</head><body><p style="margin: 2px; text-align: center;">some content</p></body></html>';
+        $expected = '<p style="margin: 1px !ImPorTant; text-align: center; padding: 1px;">';
+        $this->subject->setHtml($html);
+        $this->subject->setCss($css);
+
+        self::assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyHandleImportantStyleTagAndAttribute()
+    {
+        $css = 'p { margin: 1px !important; padding: 1px;}';
+        $html = $this->html5DocumentType . self::LF .
+            '<html><head</head><body><p style="margin: 2px !important; text-align: center;">some content</p>' .
+            '</body></html>';
+        $expected = '<p style="margin: 2px !important; text-align: center; padding: 1px;">';
+        $this->subject->setHtml($html);
+        $this->subject->setCss($css);
+
+        self::assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
 }


### PR DESCRIPTION
These changes allow Emogrifier to support `!important` like how browsers handle it.

Whenever a CSS expression in `<style>` tag ends with `!important`, it will overwrite any non-`!important` expressions in inline `style=""` attributes.

Unittests included to test both old and new behaviour.