### PR TITLE
emogrifyBodyContent() method, returning only the HTML within <body> tag.

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -181,7 +181,8 @@ class Emogrifier
     }
 
     /**
-     * Applies the CSS you submit to the HTML you submit.
+     * Applies $this->css to $this->html and returns the HTML with the CSS
+     * applied.
      *
      * This method places the CSS inline.
      *
@@ -196,6 +197,49 @@ class Emogrifier
         }
 
         $xmlDocument = $this->createXmlDocument();
+        $this->process($xmlDocument);
+
+        return $xmlDocument->saveHTML();
+    }
+
+    /**
+     * Applies $this->css to $this->html and returns only the HTML content
+     * within the <body> tag.
+     *
+     * This method places the CSS inline.
+     *
+     * @return string
+     *
+     * @throws \BadMethodCallException
+     */
+    public function emogrifyBodyContent()
+    {
+        if ($this->html === '') {
+            throw new \BadMethodCallException('Please set some HTML first before calling emogrify.', 1390393096);
+        }
+
+        $xmlDocument = $this->createXmlDocument();
+        $this->process($xmlDocument);
+
+        $innerDocument = new \DOMDocument();
+        foreach ($xmlDocument->documentElement->getElementsByTagName('body')->item(0)->childNodes as $childNode) {
+            $innerDocument->appendChild($innerDocument->importNode($childNode, true));
+        }
+
+        return $innerDocument->saveHTML();
+    }
+
+    /**
+     * Applies $this->css to $xmlDocument.
+     *
+     * This method places the CSS inline.
+     *
+     * @param \DOMDocument $xmlDocument
+     *
+     * @return void
+     */
+    protected function process(\DOMDocument $xmlDocument)
+    {
         $xpath = new \DOMXPath($xmlDocument);
         $this->clearAllCaches();
 
@@ -297,8 +341,6 @@ class Emogrifier
         }
 
         $this->copyCssWithMediaToStyleNode($cssParts, $xmlDocument);
-
-        return $xmlDocument->saveHTML();
     }
 
     /**

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -75,6 +75,29 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     *
+     * @expectedException \BadMethodCallException
+     */
+    public function emogrifyBodyContentForNoDataSetReturnsThrowsException()
+    {
+        $this->subject->emogrifyBodyContent();
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \BadMethodCallException
+     */
+    public function emogrifyBodyContentForEmptyHtmlAndEmptyCssThrowsException()
+    {
+        $this->subject->setHtml('');
+        $this->subject->setCss('');
+
+        $this->subject->emogrifyBodyContent();
+    }
+
+    /**
+     * @test
      */
     public function emogrifyAddsHtmlTagIfNoHtmlTagAndNoHeadTagAreProvided()
     {
@@ -1517,6 +1540,47 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         self::assertContains(
             '<body><p></p></body>',
             $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyReturnsCompleteHtmlDocument()
+    {
+        $this->subject->setHtml($this->html5DocumentType . '<html><body><p></p></body></html>');
+
+        self::assertSame(
+            $this->html5DocumentType . self::LF .
+            '<html>' . self::LF .
+            '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' . self::LF .
+            '<body><p></p></body>' . self::LF .
+            '</html>' . self::LF,
+            $this->subject->emogrify()
+        );
+    }
+    
+    /**
+     * @test
+     */
+    public function emogrifyBodyContentReturnsBodyContentFromHtml()
+    {
+        $this->subject->setHtml($this->html5DocumentType . '<html><body><p></p></body></html>');
+        self::assertSame(
+            '<p></p>' . self::LF,
+            $this->subject->emogrifyBodyContent()
+        );
+    }
+    
+    /**
+     * @test
+     */
+    public function emogrifyBodyContentReturnsBodyContentFromContent()
+    {
+        $this->subject->setHtml('<p></p>');
+        self::assertSame(
+            '<p></p>' . self::LF,
+            $this->subject->emogrifyBodyContent()
         );
     }
 }


### PR DESCRIPTION
Included a `returnBodyContentOnly ()` function which, after called to enable the feature, will return the content of the `<body>` tag only, instead of the entire HTML.

For instance, `<!DOCTYPE html><html><head>...</head><body><p>Hello</p></body><html>` will return just `<p>Hello</p>`. This allows Emogrifier to be used on fragments of HTML code instead of entire files.

Unittests are included to test both default and feature behaviour.

If you prefer different function names, please let me know.