### PR TITLE
addExcludedSelector()/removeExcludedSelector()

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -72,6 +72,8 @@ class Emogrifier
      * @var string
      */
     private $css = '';
+    
+    private $excludedSelectors = [];
 
     /**
      * @var string[]
@@ -263,6 +265,16 @@ class Emogrifier
             $this->caches[self::CACHE_KEY_CSS][$cssKey] = $allSelectors;
         }
 
+        // Prepare the list of excluded nodes
+        $excludedNodes = [];
+        foreach ($this->excludedSelectors as $selectorString) {
+            foreach (explode(',', $selectorString) as $selector) {
+                foreach ($xpath->query($this->translateCSStoXpath(trim($selector))) as $node) {
+                    $excludedNodes[] = $node;
+                }
+            }
+        }
+
         foreach ($this->caches[self::CACHE_KEY_CSS][$cssKey] as $value) {
             // query the body for the xpath selector
             $nodesMatchingCssSelectors = $xpath->query($this->translateCssToXpath($value['selector']));
@@ -270,9 +282,18 @@ class Emogrifier
             if ($nodesMatchingCssSelectors === false) {
                 continue;
             }
-
+            
             /** @var \DOMElement $node */
             foreach ($nodesMatchingCssSelectors as $node) {
+                // Skip excluded nodes
+                if (!empty($excludedNodes)) {
+                    foreach ($excludedNodes as $excludedNode) {
+                        if ($excludedNode->isSameNode($node)) {
+                            continue 2;
+                        }
+                    }
+                }
+
                 // if it has a style attribute, get it, process it, and append (overwrite) new stuff
                 if ($node->hasAttribute('style')) {
                     // break it up into an associative array
@@ -410,6 +431,32 @@ class Emogrifier
         if ($key !== false) {
             unset($this->unprocessableHtmlTags[$key]);
         }
+    }
+    
+    /**
+     * Adds a selector to exclude nodes from processing
+     *
+     * Any nodes that match the selector will not have their style altered.
+     *
+     * @param string $selector the selector to exclude, e.g., ".editor"
+     *
+     * @return void
+     */
+    public function addExcludedSelector($selector)
+    {
+        $this->excludedSelectors[] = $selector;
+    }
+
+    /**
+     * No longer exclude the nodes matching this selector.
+     *
+     * @param string $selector the selector to exclude, e.g., ".editor"
+     *
+     * @return void
+     */
+    public function removeExcludedSelector($selector)
+    {
+        $this->excludedSelectors = array_diff($this->excludedSelectors, [$selector]);
     }
 
     /**

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1519,4 +1519,28 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             $this->subject->emogrify()
         );
     }
+
+    /**
+     * @test
+     */
+    public function emogrifyExcludeSelector()
+    {
+        $css = 'p { margin: 0; }';
+        $this->subject->setHtml($this->html5DocumentType . '<html><body>' .
+            '<p class="x"></p><p></p></body></html>');
+        $this->subject->setCss($css);
+        $this->subject->addExcludedSelector('p.x');
+
+        $html = $this->subject->emogrify();
+
+        self::assertContains(
+            '<p class="x"></p>',
+            $html
+        );
+
+        self::assertContains(
+            '<p style="margin: 0;"></p>',
+            $html
+        );
+    }
 }


### PR DESCRIPTION
Added methods `addExcludedSelector()` and `removeExcludedSelector()` that let you add selectors which should be excluded from processing. This is convenient to filter out nodes that are needed by other tools without having to change the style.

A unittest is included.