### PR TITLE
[CLEANUP] Reformat the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,26 @@
 [![Latest Unstable Version](https://poser.pugx.org/pelago/emogrifier/v/unstable.svg)](https://packagist.org/packages/pelago/emogrifier)
 [![License](https://poser.pugx.org/pelago/emogrifier/license.svg)](https://packagist.org/packages/pelago/emogrifier)
 
-_n. e•mog•ri•fi•er [\ē-'mä-grƏ-,fī-Ər\] - a utility for changing completely the nature or appearance of HTML email,
-esp. in a particularly fantastic or bizarre manner_
+_n. e•mog•ri•fi•er [\ē-'mä-grƏ-,fī-Ər\] - a utility for changing completely the
+nature or appearance of HTML email, esp. in a particularly fantastic or bizarre
+manner_
 
-Emogrifier converts CSS styles into inline style attributes in your HTML code. This ensures proper display on email
-and mobile device readers that lack stylesheet support.
+Emogrifier converts CSS styles into inline style attributes in your HTML code.
+This ensures proper display on email and mobile device readers that lack
+stylesheet support.
 
-This utility was developed as part of [Intervals](http://www.myintervals.com/) to deal with the problems posed by
-certain email clients (namely Outlook 2007 and Google Gmail) when it comes to the way they handle styling contained
-in HTML emails. As many web developers and designers already know, certain email clients are notorious for their
-lack of CSS support. While attempts are being made to develop common
-[email standards](http://www.email-standards.org/), implementation is still a ways off.
+This utility was developed as part of [Intervals](http://www.myintervals.com/)
+to deal with the problems posed by certain email clients (namely Outlook 2007
+and GoogleMail) when it comes to the way they handle styling contained in HTML
+emails. As many web developers and designers already know, certain email
+clients are notorious for their lack of CSS support. While attempts are being
+made to develop common [email standards](http://www.email-standards.org/),
+implementation is still a ways off.
 
-The primary problem with uncooperative email clients is that most tend to only regard inline CSS, discarding all
-`<style>` elements and links to stylesheets in `<link>` elements. Emogrifier solves this problem by converting CSS
-styles into inline style attributes in your HTML code.
-
+The primary problem with uncooperative email clients is that most tend to only
+regard inline CSS, discarding all `<style>` elements and links to stylesheets
+in `<link>` elements. Emogrifier solves this problem by converting CSS styles
+into inline style attributes in your HTML code.
 
 - [How it works](#how-it-works)
 - [Usage](#usage)
@@ -33,17 +37,17 @@ styles into inline style attributes in your HTML code.
 - [Contributing](#contributing)
 
 
-
 ## How it Works
 
-Emogrifier automagically transmogrifies your HTML by parsing your CSS and inserting your CSS definitions into tags
-within your HTML based on your CSS selectors.
+Emogrifier automagically transmogrifies your HTML by parsing your CSS and
+inserting your CSS definitions into tags within your HTML based on your CSS
+selectors.
 
 
 ## Usage
 
-First, you provide Emogrifier with the HTML and CSS you would like to merge. This can happen directly during
-instantiation:
+First, you provide Emogrifier with the HTML and CSS you would like to merge.
+This can happen directly during instantiation:
 
     $html = '<html><h1>Hello world!</h1></html>';
     $css = 'h1 {font-size: 32px;}';
@@ -59,7 +63,8 @@ You could also use the setters for providing this data after instantiation:
     $emogrifier->setHtml($html);
     $emogrifier->setCss($css);
 
-After you have set the HTML and CSS, you can call the `emogrify` method to merge both:
+After you have set the HTML and CSS, you can call the `emogrify` method to
+merge both:
 
     $mergedHtml = $emogrifier->emogrify();
 
@@ -96,7 +101,8 @@ calling the `emogrify` method:
 
 ## Installing with Composer
 
-Download the [`composer.phar`](https://getcomposer.org/composer.phar) locally or install [Composer](https://getcomposer.org/) globally:
+Download the [`composer.phar`](https://getcomposer.org/composer.phar) locally
+or install [Composer](https://getcomposer.org/) globally:
 
     curl -s https://getcomposer.org/installer | php
 
@@ -108,7 +114,8 @@ Or for a global installation, run the following command:
 
     composer require pelago/emogrifier:@dev
 
-You can also add follow lines to your `composer.json` and run the `composer update` command:
+You can also add follow lines to your `composer.json` and run the
+`composer update` command:
 
     "require": {
       "pelago/emogrifier": "@dev"
@@ -119,7 +126,8 @@ See https://getcomposer.org/ for more information and documentation.
 
 ## Supported CSS selectors
 
-Emogrifier currently support the following [CSS selectors](http://www.w3.org/TR/CSS2/selector.html):
+Emogrifier currently support the following
+[CSS selectors](http://www.w3.org/TR/CSS2/selector.html):
 
  * ID
  * class
@@ -143,20 +151,25 @@ The following selectors are not implemented yet:
 
 ## Caveats
 
-* Emogrifier requires the HTML and the CSS to be UTF-8. Encodings like ISO8859-1 or ISO8859-15 are not supported.
-* **NEW:** Emogrifier now preserves all valuable @media queries. Media queries can be very useful in
-  responsive email design. See [media query support](https://litmus.com/help/email-clients/media-query-support/).
-* **NEW:** Emogrifier will grab existing inline style attributes _and_ will grab `<style>` blocks from your HTML, but it
-  will not grab CSS files referenced in <link> elements (the problem email clients are going to ignore these tags
-  anyway, so why leave them in your HTML?).
-* Even with styles inline, certain CSS properties are ignored by certain email clients. For more information,
-  refer to these resources:
+* Emogrifier requires the HTML and the CSS to be UTF-8. Encodings like
+  ISO8859-1 or ISO8859-15 are not supported.
+* **NEW:** Emogrifier now preserves all valuable @media queries. Media queries
+  can be very useful in responsive email design. See
+  [media query support](https://litmus.com/help/email-clients/media-query-support/).
+* **NEW:** Emogrifier will grab existing inline style attributes _and_ will
+  grab `<style>` blocks from your HTML, but it will not grab CSS files
+  referenced in <link> elements. (The problem email clients are going to ignore
+  these tags anyway, so why leave them in your HTML?)
+* Even with styles inline, certain CSS properties are ignored by certain email
+  clients. For more information, refer to these resources:
     * [http://www.email-standards.org/](http://www.email-standards.org/)
     * [https://www.campaignmonitor.com/css/](https://www.campaignmonitor.com/css/)
     * [http://templates.mailchimp.com/resources/email-client-css-support/](http://templates.mailchimp.com/resources/email-client-css-support/)
-* All CSS attributes that apply to a node will be applied, even if they are redundant. For example, if you define a
-  font attribute _and_ a font-size attribute, both attributes will be applied to that node (in other words, the more
-  specific attribute will not be combined into the more general attribute).
+* All CSS attributes that apply to a node will be applied, even if they are
+  redundant. For example, if you define a font attribute _and_ a font-size
+  attribute, both attributes will be applied to that node (in other words, the
+  more specific attribute will not be combined into the more general
+  attribute).
 * There's a good chance you might encounter problems if your HTML is not
   well-formed and valid (DOMDocument might complain). If you get problems like
   this, consider running your HTML through
@@ -165,12 +178,14 @@ The following selectors are not implemented yet:
 * Emogrifier automatically converts the provided (X)HTML into HTML, i.e.,
   self-closing tags will lose their slash. To keep your HTML valid, it is
   recommended to use HTML5 instead of one of the XHTML variants.
-* Finally, Emogrifier only supports CSS1 level selectors and a few CSS2 level selectors (but not all of them). It
-  does not support pseudo selectors (Emogrifier works by converting CSS selectors to XPath selectors, and pseudo
-  selectors cannot be converted accurately).
+* Emogrifier only supports CSS1 level selectors and a few CSS2 level selectors
+  (but not all of them). It does not support pseudo selectors. (Emogrifier
+  works by converting CSS selectors to XPath selectors, and pseudo selectors
+  cannot be converted accurately).
 * `!important` currently is not supported yet.
 
 
 ## Maintainer
 
-Emogrifier is maintained by the good people at [Pelago](http://www.pelagodesign.com/), info AT pelagodesign DOT com.
+Emogrifier is maintained by the good people at
+[Pelago](http://www.pelagodesign.com/), info AT pelagodesign DOT com.


### PR DESCRIPTION
The lines in the README are now no longer than 80 characters (with
exceptions for lines with long links). This will make viewing this
file in raw format or in a diff a lot nicer on GitHub.

[ci skip]

Fixes #167