### PR TITLE
Add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,10 @@
         "psr-4": {
             "Pelago\\": "Classes/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
     }
 }


### PR DESCRIPTION
It'd be great to add this alias so we can require the package as `^1.0@dev` instead of just `@dev`, because the former won't install 2.0 releases, while the latter does and that's very dangerous. See https://getcomposer.org/doc/articles/aliases.md#branch-alias for details

Also it'd be nice if you could tag a release every now and then :)