### PR TITLE
Fix for multi-line media queries

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -671,6 +671,7 @@ class Emogrifier
             foreach ($this->parseSelectors($mediaQuery['css']) as $selector) {
                 if ($this->existsMatchForCssSelector($xpath, $selector['selector'])) {
                     $mediaQueriesRelevantForDocument[] = $mediaQuery['query'];
+                    break;
                 }
             }
         }
@@ -687,8 +688,7 @@ class Emogrifier
      */
     private function extractMediaQueriesFromCss($css)
     {
-        preg_match_all('#(?<query>@media[^{]*\\{(?<css>(.*?)\\})(\\s*)\\})#', $css, $mediaQueries);
-
+        preg_match_all('#(?<query>@media[^{]*\\{(?<css>(.*?)\\})(\\s*)\\})#s', $css, $mediaQueries);
         $result = [];
         foreach (array_keys($mediaQueries['css']) as $key) {
             $result[] = [

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1763,4 +1763,27 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             $result
         );
     }
+
+    /**
+     * @test
+     */
+    public function multiLineMediaQuery()
+    {
+        $mediaQuery = "@media all and (max-width: 500px) {\r\n"
+                . ".medium {font-size:18px;}\r\n"
+                . ".small {font-size:14px;}\r\n"
+                . "}";
+        $this->subject->setCss($mediaQuery);
+
+        $this->subject->setHtml($this->html5DocumentType . '<html><body>'
+                . '<p class="medium">medium</p>'
+                . '<p class="small">small</p>'
+                . '</body></html>');
+        $result = $this->subject->emogrify();
+
+        self::assertContains(
+            $mediaQuery,
+            $result
+        );
+    }
 }

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1769,16 +1769,16 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function multiLineMediaQuery()
     {
-        $mediaQuery = "@media all and (max-width: 500px) {\r\n"
-                . ".medium {font-size:18px;}\r\n"
-                . ".small {font-size:14px;}\r\n"
-                . "}";
+        $mediaQuery = "@media all and (max-width: 500px) {\r\n" .
+                ".medium {font-size:18px;}\r\n" .
+                ".small {font-size:14px;}\r\n" .
+                '}';
         $this->subject->setCss($mediaQuery);
 
-        $this->subject->setHtml($this->html5DocumentType . '<html><body>'
-                . '<p class="medium">medium</p>'
-                . '<p class="small">small</p>'
-                . '</body></html>');
+        $this->subject->setHtml($this->html5DocumentType . '<html><body>' .
+                '<p class="medium">medium</p>' .
+                '<p class="small">small</p>' .
+                '</body></html>');
         $result = $this->subject->emogrify();
 
         self::assertContains(


### PR DESCRIPTION
Add s modifier to regex so . matches newline. And break so a query is only added once.

I found that multi-line media queries are removed by emogrifier. This is because the regex to find them doesn't handle multi-line declarations.

This fix adds the s modifier to the regex so that the newline character can be part of the CSS.

And to prevent emogrifier to add the same media query for every selector matching an element, a break is added to the loop finding matching selectors.