### PR TITLE
Bugfix multiline media queries2

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -671,6 +671,7 @@ class Emogrifier
             foreach ($this->parseSelectors($mediaQuery['css']) as $selector) {
                 if ($this->existsMatchForCssSelector($xpath, $selector['selector'])) {
                     $mediaQueriesRelevantForDocument[] = $mediaQuery['query'];
+                    break;
                 }
             }
         }
@@ -687,8 +688,7 @@ class Emogrifier
      */
     private function extractMediaQueriesFromCss($css)
     {
-        preg_match_all('#(?<query>@media[^{]*\\{(?<css>(.*?)\\})(\\s*)\\})#', $css, $mediaQueries);
-
+        preg_match_all('#(?<query>@media[^{]*\\{(?<css>(.*?)\\})(\\s*)\\})#s', $css, $mediaQueries);
         $result = [];
         foreach (array_keys($mediaQueries['css']) as $key) {
             $result[] = [

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1763,4 +1763,77 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             $result
         );
     }
+
+    /**
+     * @test
+     */
+    public function multiLineMediaQueryIsAppliedOnce()
+    {
+        $css = "@media all {\r\n" .
+                ".medium {font-size:18px;}\r\n" .
+                ".small {font-size:14px;}\r\n" .
+                '}';
+        $this->subject->setCss($css);
+
+        $this->subject->setHtml($this->html5DocumentType . '<html><body>' .
+                '<p class="medium">medium</p>' .
+                '<p class="small">small</p>' .
+                '</body></html>');
+        $result = $this->subject->emogrify();
+
+        self::assertContains(
+            '<style type="text/css">' . $css . '</style>',
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function unixStyleMultiLineMediaQueryIsAppliedOnce()
+    {
+        $css = "@media all {\n" .
+                ".medium {font-size:18px;}\n" .
+                ".small {font-size:14px;}\n" .
+                '}';
+        $this->subject->setCss($css);
+
+        $this->subject->setHtml($this->html5DocumentType . '<html><body>' .
+                '<p class="medium">medium</p>' .
+                '<p class="small">small</p>' .
+                '</body></html>');
+        $result = $this->subject->emogrify();
+
+        self::assertContains(
+            '<style type="text/css">' . $css . '</style>',
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function multipleMediaQueresAreAppliedOnce()
+    {
+        $css = "@media all {\r\n" .
+                ".medium {font-size:18px;}\r\n" .
+                ".small {font-size:14px;}\r\n" .
+                '}' .
+                "@media screen {\r\n" .
+                ".medium {font-size:24px;}\r\n" .
+                ".small {font-size:18px;}\r\n" .
+                '}';
+        $this->subject->setCss($css);
+
+        $this->subject->setHtml($this->html5DocumentType . '<html><body>' .
+                '<p class="medium">medium</p>' .
+                '<p class="small">small</p>' .
+                '</body></html>');
+        $result = $this->subject->emogrify();
+
+        self::assertContains(
+            '<style type="text/css">' . $css . '</style>',
+            $result
+        );
+    }
 }


### PR DESCRIPTION
Add s modifier to regex so . matches newline. And break so a query is only added once.

I found that multi-line media queries are removed by emogrifier. This is because the regex to find them doesn't handle multi-line declarations.

This fix adds the s modifier to the regex so that the newline character can be part of the CSS.

And to prevent emogrifier to add the same media query for every selector matching an element, a break is added to the loop finding matching selectors.