### PR TITLE
Fix parsing of CSS for data-uri's

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -1213,14 +1213,20 @@ class Emogrifier
         }
 
         $properties = [];
-        $declarations = explode(';', $cssDeclarationBlock);
+        /* Replace the semicolon in base64-encoded data uris with a @ to prevent breaking
+         * up these declarations
+         */
+        $mangledDeclarations = str_replace(';base64', '@base64', $cssDeclarationBlock);
+        $declarations = explode(';', $mangledDeclarations);
         foreach ($declarations as $declaration) {
             $matches = [];
             if (!preg_match('/ *([A-Za-z\\-]+) *: *([^;]+) */', $declaration, $matches)) {
                 continue;
             }
             $propertyName = strtolower($matches[1]);
-            $propertyValue = $matches[2];
+            /* Put the ; back in front of the base64 declaration
+             */
+            $propertyValue = str_replace('@base64', ';base64', $matches[2]);
             $properties[$propertyName] = $propertyValue;
         }
         $this->caches[self::CACHE_KEY_CSS_DECLARATION_BLOCK][$cssDeclarationBlock] = $properties;

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1763,4 +1763,25 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             $result
         );
     }
+
+    /**
+     * @test
+     */
+    public function dataUrisAreConserved()
+    {
+        $html = $this->html5DocumentType . '<html></html>';
+        $this->subject->setHtml($html);
+        $styleRule = 'background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAABUk' .
+                'lEQVQ4y81UsY6CQBCdWXBjYWFMjEgAE0piY8c38B9+iX+ksaHCgs5YWEhIrJCQYGJBomiC7lzhVcfqEa+5KXfey3s783bRdd00TR' .
+                'VFAQAAICJEhN/q8Xjoug7D4RA+qsFgwDjn9QYiTiaT+Xx+OByOx+NqtapjWq0WjEajekPTtCAIiIiIyrKMoqiOMQxDlVqyLMt1XQ' .
+                'A4nU6z2Wy9XkthEnK/3zdN8znC/X7v+36WZfJ7120vFos4joUQRHS5XDabzXK5bGrbtu1er/dtTFU1TWu3202VHceZTqe3242Itt' .
+                'ut53nj8bip8m6345wLIQCgKIowDIuikAoz6Wm3233mjHPe6XRe5UROJqImIWPwh/pvZMbYM2GKorx5oUw6m+v1miTJ+XzO8/x+v7' .
+                '+UtizrM8+GYahVVSFik9/jxy6rqlJN02SM1cmI+GbbQghd178AAO2FXws6LwMAAAAASUVORK5CYII=);';
+        $this->subject->setCss('html {' . $styleRule . '}');
+
+        self::assertContains(
+            '<html style="' . $styleRule . '">',
+            $this->subject->emogrify()
+        );
+    }
 }


### PR DESCRIPTION
CSS declarations with data uris contain semicolons. Semicolon is also the separator between CSS declarations. Unfortunately, this makes parsing CSS blocks a bit more complicated than just splitting the string around semicolons.

This fix covers the most widely used data uris for embedding images (base64 encoded, no charset).

By replacing the string ';base64' with '@base64' before parsing and doing the reverse after parsing, the blocks can be conveniently split around semicolons, provided there are no other semicolons lurking in the CSS.

Fixes bug #235 