### PR TITLE
[BUGFIX] Fix multi-line media queries

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -671,6 +671,7 @@ class Emogrifier
             foreach ($this->parseSelectors($mediaQuery['css']) as $selector) {
                 if ($this->existsMatchForCssSelector($xpath, $selector['selector'])) {
                     $mediaQueriesRelevantForDocument[] = $mediaQuery['query'];
+                    break;
                 }
             }
         }
@@ -687,8 +688,7 @@ class Emogrifier
      */
     private function extractMediaQueriesFromCss($css)
     {
-        preg_match_all('#(?<query>@media[^{]*\\{(?<css>(.*?)\\})(\\s*)\\})#', $css, $mediaQueries);
-
+        preg_match_all('#(?<query>@media[^{]*\\{(?<css>(.*?)\\})(\\s*)\\})#s', $css, $mediaQueries);
         $result = [];
         foreach (array_keys($mediaQueries['css']) as $key) {
             $result[] = [

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1763,4 +1763,81 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             $result
         );
     }
+
+    /**
+     * @test
+     */
+    public function multiLineMediaQueryWithWindowsLineEndingsIsAppliedOnlyOnce()
+    {
+        $css = "@media all {\r\n" .
+            ".medium {font-size:18px;}\r\n" .
+            ".small {font-size:14px;}\r\n" .
+            '}';
+        $this->subject->setCss($css);
+        $this->subject->setHtml($this->html5DocumentType . '<html><body>' .
+            '<p class="medium">medium</p>' .
+            '<p class="small">small</p>' .
+            '</body></html>');
+
+        $result = $this->subject->emogrify();
+
+        self::assertSame(
+            1,
+            substr_count($result, '<style type="text/css">' . $css . '</style>')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function multiLineMediaQueryWithUnixLineEndingsIsAppliedOnlyOnce()
+    {
+        $css = "@media all {\n" .
+            ".medium {font-size:18px;}\n" .
+            ".small {font-size:14px;}\n" .
+            '}';
+        $this->subject->setCss($css);
+        $this->subject->setHtml(
+            $this->html5DocumentType . '<html><body>' .
+            '<p class="medium">medium</p>' .
+            '<p class="small">small</p>' .
+            '</body></html>'
+        );
+
+        $result = $this->subject->emogrify();
+
+        self::assertSame(
+            1,
+            substr_count($result, '<style type="text/css">' . $css . '</style>')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function multipleMediaQueriesAreAppliedOnlyOnce()
+    {
+        $css = "@media all {\n" .
+            ".medium {font-size:18px;\n" .
+            ".small {font-size:14px;}\n" .
+            '}' .
+            "@media screen {\n" .
+            ".medium {font-size:24px;}\n" .
+            ".small {font-size:18px;}\n" .
+            '}';
+        $this->subject->setCss($css);
+        $this->subject->setHtml(
+            $this->html5DocumentType . '<html><body>' .
+            '<p class="medium">medium</p>' .
+            '<p class="small">small</p>' .
+            '</body></html>'
+        );
+
+        $result = $this->subject->emogrify();
+
+        self::assertSame(
+            1,
+            substr_count($result, '<style type="text/css">' . $css . '</style>')
+        );
+    }
 }


### PR DESCRIPTION
Add s modifier to regex so . matches newline. And break so a query
is only added once.

Fixes #234