### PR TITLE
[FEATURE] Add CSS to HTML attribute mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ calling the `emogrify` method:
   method to remove media types that Emogrifier keeps.
 * `$emogrifier->addExcludedSelector(string $selector)` - Keeps elements from
   being affected by emogrification.
+* `$emogrifier->enableCss2HtmlMapping()` - Some email clients don't support CSS
+  well, even if inline and prefer HTML attributes. This function allows you to
+  put properties such as height, width, background color and font color in your
+  CSS while the transformed content will have all the available HTML tags set.
 
 
 ## Requirements

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1945,4 +1945,73 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             $result
         );
     }
+
+    /**
+     * Data provider for css to html mapping.
+     *
+     * @return array[]
+     */
+    public function cssToHtmlMappingDataProvider()
+    {
+        return [
+            'Map background-color to bgcolor'
+                => ['', 'body {background-color: red;}', 'body', 'bgcolor="red"'],
+            'Do not map background URL'
+                => ['', 'body {background: url(bg.png) top;}', 'body', 'style'],
+            'Map text-align to align'
+                => ['<p>hi</p>', 'p {text-align: justify;}', 'p', 'align="justify"'],
+            'Do not map text-align to align'
+                => ['<span>hi</span>', 'span {text-align: justify;}', 'span', 'style'],
+            'Map float: right to align=right'
+                => ['<img>', 'img {float: right;}', 'img', 'align="right"'],
+            'Do not map float to align'
+                => ['<span>hi</span>', 'span {float: right;}', 'span', 'style'],
+            'Map background to bgcolor'
+                => ['', 'body {background: red top;}', 'body', 'bgcolor="red"'],
+            'Map width and height'
+                => ['', 'body {width: 100%; height: 200px;}', 'body', 'width="100%" height="200"'],
+            'Map text-align: center to align=center'
+                => ['<p>mid</p>', 'p {text-align: center;}', 'p', 'align="center"'],
+            'Do not map text-align: inherit'
+                => ['<p>plain</p>', 'p {text-align: interit;}', 'p', 'style'],
+            'Map margin: 0 auto to align=center'
+                => ['<img>', 'img {margin: 0 auto;}', 'img', 'align="center"'],
+            'Map margin: auto to align=center'
+                => ['<img>', 'img {margin: auto;}', 'img', 'align="center"'],
+            'Map margin: 10 auto 30 auto to align=center'
+                => ['<img>', 'img {margin: 10 auto 30 auto;}', 'img', 'align="center"'],
+            'Do not map margin: 10 5 30 auto to align=center'
+                => ['<img>', 'img {margin: 10 5 30 auto;}', 'img', 'style'],
+            'Map float: right to align=right'
+                => ['<img>', 'img {float: right;}', 'img', 'align="right"'],
+            'Map border: none to border=0'
+                => ['<img>', 'img {border: none;}', 'img', 'border="0"'],
+            'Do not map border: none to border'
+                => ['<span>hi</span>', 'span {border: none;}', 'span', 'style'],
+            'Map border-spacing: 0 to cellspacing=0'
+                => ['<table><tr><td></td></tr></table>', 'table {border-spacing: 0;}', 'table', 'cellspacing="0"']
+        ];
+    }
+    
+    /**
+     * @test
+     * @param string $body          The HTML
+     * @param string $css           The complete CSS
+     * @param string $tagName       The name of the tag that should be modified
+     * @param string $attributes    The attributes that are expected on the element
+     *
+     * @dataProvider cssToHtmlMappingDataProvider
+     */
+    public function emogrifierMapsCssToHtml($body, $css, $tagName, $attributes)
+    {
+        $this->subject->setHtml($this->html5DocumentType . '<html><body>' . $body . '</body></html>');
+        $this->subject->setCss($css);
+        $this->subject->enableCssToHtmlMapping();
+        $html = $this->subject->emogrify();
+
+        self::assertContains(
+            '<' . $tagName . ' ' . $attributes,
+            $html
+        );
+    }
 }


### PR DESCRIPTION
I moved pull-request #232 to a new branch so I can do other stuff on my master branch.

This addition enables you to put more styles in the CSS and dismisses the need to put for example width and height attributes inline. Outlook 2007, for example will ignore width and height CSS properties on images so you really need the width and height as HTML attributes.

mapStyles2HTMLAttrs takes CSS properties that have HTML equivalents and adds these HTML attributes to the DOM nodes.

The biggest advantage I see is that you can have cleaner HTML markup and more easy building a system with email messages that can be branded dynamically with different stylesheets.