### PR TITLE
[BUGFIX] Parsing CSS declaration blocks

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -1209,19 +1209,17 @@ class Emogrifier
         }
 
         $properties = [];
+        $declarations = preg_split('/;(?!base64|charset)/', $cssDeclarationsBlock);
 
-        // Replace the semicolon in base64-encoded data URIs with a @ to prevent breaking
-        // up these declarations.
-        $mangledDeclarationsBlock = str_replace(';base64', '@base64', $cssDeclarationsBlock);
-        $declarations = explode(';', $mangledDeclarationsBlock);
         foreach ($declarations as $declaration) {
+            $declaration = trim($declaration);
             $matches = [];
-            if (!preg_match('/ *([A-Za-z\\-]+) *: *([^;]+) */', $declaration, $matches)) {
+
+            if (!preg_match('/^([A-Za-z\\-]+)\\s*:\\s*(.+)$/', $declaration, $matches)) {
                 continue;
             }
             $propertyName = strtolower($matches[1]);
-            // Put the semicolon back in front of the base64 declaration
-            $propertyValue = str_replace('@base64', ';base64', $matches[2]);
+            $propertyValue = $matches[2];
             $properties[$propertyName] = $propertyValue;
         }
         $this->caches[self::CACHE_KEY_CSS_DECLARATIONS_BLOCK][$cssDeclarationsBlock] = $properties;


### PR DESCRIPTION
Revert to splitting declaration blocks using a regex.
Split on ; except when it is followed by charset or base64.
Make the validation of property/value pairs and surrounding white space more
robust.

Prior to the changes three tests failed
* nl before colon and after value, trailing semicolon
* one declaration with missing dash in property name
* one declaration with invalid character in property name

There seems to be an odd, to me, convention of using double backslashes when only one is needed (such as \s*), and also using backslash when it is not needed (such as for - in [A-Za-z-]. These changes haven't followed that convention.