### PR TITLE
Adds a range of features including state selectors and namespace overrides

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -464,6 +464,11 @@ class Emogrifier
         $this->shouldKeepInvisibleNodes = false;
     }
 
+    /**
+     * Adds Styles to the head of the files over the body node
+     *
+     * @return void
+     */
     public function appendStylesToHead()
     {
         $this->appendStylesToBody = false;

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -690,8 +690,7 @@ class Emogrifier
             // And the new style includes an override like padding: 5px;
             // And is not tagged as !important
             $attributeNameSpace = explode('-', $attributeName);
-            if (
-                count($attributeNameSpace) > 1 &&
+            if (count($attributeNameSpace) > 1 &&
                 isset($newStyles[$attributeNameSpace[0]])
                 && !(strtolower(substr($attributeValue, -10)) === '!important')
             ) {

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -813,8 +813,13 @@ class Emogrifier
         $styleAttribute->value = 'text/css';
         $styleElement->appendChild($styleAttribute);
 
+        $body = $document->getElementsByTagName('body')->item(0);
+        if (!$body) {
+            $body = $document->createElement('body');
+            $document->insertBefore($body);
+        }
+
         if ($this->appendStylesToBody) {
-            $body = $document->getElementsByTagName('body')->item(0);
             $body->insertBefore($styleElement, $body->firstChild);
         } else {
             $head = $this->getOrCreateHeadElement($document);

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -418,6 +418,11 @@ class Emogrifier
         $this->shouldKeepInvisibleNodes = false;
     }
 
+    public function appendStylesToHead()
+    {
+        $this->appendStylesToBody = false;
+    }
+
     /**
      * Clears all caches.
      *
@@ -779,7 +784,7 @@ class Emogrifier
 
         if ($this->appendStylesToBody) {
             $body = $document->getElementsByTagName('body')->item(0);
-            $body->insertBefore($styleElement, $body->childNodes->item(0));
+            $body->insertBefore($styleElement, $body->firstChild);
         } else {
             $head = $this->getOrCreateHeadElement($document);
             $head->appendChild($styleElement);

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -343,8 +343,10 @@ class Emogrifier
         }
 
         $this->copyCssWithMediaToStyleNode($xmlDocument, $xPath, $cssParts['media']);
-        $this->addStyleElementToDocument($xmlDocument, $cssParts['states']);
-        if($this->shouldAppendCssAsStyleNode) {
+        if (strlen($cssParts['states'])) {
+            $this->addStyleElementToDocument($xmlDocument, $cssParts['states']);
+        }
+        if($this->shouldAppendCssAsStyleNode && strlen($cssParts['css']) > 0) {
             $this->addStyleElementToDocument($xmlDocument, $cssParts['css']);
         }
     }
@@ -731,7 +733,10 @@ class Emogrifier
             }
         }
 
-        $this->addStyleElementToDocument($xmlDocument, implode('', $mediaQueriesRelevantForDocument));
+        $media = implode('', $mediaQueriesRelevantForDocument);
+        if (strlen($media) > 0) {
+            $this->addStyleElementToDocument($xmlDocument, implode('', $mediaQueriesRelevantForDocument));
+        }
     }
 
     /**

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -682,19 +682,21 @@ class Emogrifier
         }
 
         foreach ($oldStyles as $attributeName => $attributeValue) {
+            // If the new style has an !important tag
             if (isset($newStyles[$attributeName]) && strtolower(substr($attributeValue, -10)) === '!important') {
                 $combinedStyles[$attributeName] = $attributeValue;
             }
-        }
-
-        // recalculate styles based on sub keys from classes e.g. padding:0; should
-        // override padding-top:10px; set by previous classes
-        foreach (array_keys($newStyles) as $newAttribute) {
-            foreach (array_keys($oldStyles) as $oldAttribute) {
-                // if a old attribute starts with the new attribute key then remove it from the old styles
-                if ($newAttribute === '' || strrpos($oldAttribute, $newAttribute, -strlen($oldAttribute)) !== false) {
-                    unset($oldStyles[$oldAttribute]);
-                }
+            // If the attribute is apart of a namespace e.g. padding-top: 10px;
+            // And the new style includes an override like padding: 5px;
+            // And is not tagged as !important
+            $attributeNameSpace = explode('-', $attributeName);
+            if (
+                count($attributeNameSpace) > 1 &&
+                isset($newStyles[$attributeNameSpace[0]])
+                && !(strtolower(substr($attributeValue, -10)) === '!important')
+            ) {
+                // Remove the attribute with the namespace e.g. padding-top: 10px;
+                unset($combinedStyles[$attributeName]);
             }
         }
 

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -154,6 +154,14 @@ class Emogrifier
     private $shouldKeepInvisibleNodes = true;
 
     /**
+     * Determines if the body element should store the style blocks for media otherwise it should be stored in the
+     * head element for outputted html
+     *
+     * @var bool
+     */
+    private $appendStylesToBody = true;
+
+    /**
      * The constructor.
      *
      * @param string $html the HTML to emogrify, must be UTF-8-encoded
@@ -769,8 +777,13 @@ class Emogrifier
         $styleAttribute->value = 'text/css';
         $styleElement->appendChild($styleAttribute);
 
-        $head = $this->getOrCreateHeadElement($document);
-        $head->appendChild($styleElement);
+        if ($this->appendStylesToBody) {
+            $body = $document->getElementsByTagName('body')->item(0);
+            $body->insertBefore($styleElement, $body->childNodes->item(0));
+        } else {
+            $head = $this->getOrCreateHeadElement($document);
+            $head->appendChild($styleElement);
+        }
     }
 
     /**

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -346,7 +346,7 @@ class Emogrifier
         if (strlen($cssParts['states'])) {
             $this->addStyleElementToDocument($xmlDocument, $cssParts['states']);
         }
-        if($this->shouldAppendCssAsStyleNode && strlen($cssParts['css']) > 0) {
+        if ($this->shouldAppendCssAsStyleNode && strlen(preg_replace('/\s+/', '', $cssParts['css'])) > 0) {
             $this->addStyleElementToDocument($xmlDocument, $cssParts['css']);
         }
     }
@@ -675,16 +675,6 @@ class Emogrifier
      */
     private function generateStyleStringFromDeclarationsArrays(array $oldStyles, array $newStyles)
     {
-        // recalculate styles based on sub keys from classes e.g. padding:0; should override padding-top:10px; set by previous classes
-        foreach (array_keys($newStyles) as $newAttribute) {
-            foreach (array_keys($oldStyles) as $oldAttribute) {
-                // if a old attribute starts with the new attribute key then remove it from the old styles
-                if ($newAttribute === "" || strrpos($oldAttribute, $newAttribute, -strlen($oldAttribute)) !== FALSE) {
-                    unset($oldStyles[$oldAttribute]);
-                }
-            }
-        }
-
         $combinedStyles = array_merge($oldStyles, $newStyles);
         $cacheKey = serialize($combinedStyles);
         if (isset($this->caches[self::CACHE_KEY_COMBINED_STYLES][$cacheKey])) {
@@ -694,6 +684,17 @@ class Emogrifier
         foreach ($oldStyles as $attributeName => $attributeValue) {
             if (isset($newStyles[$attributeName]) && strtolower(substr($attributeValue, -10)) === '!important') {
                 $combinedStyles[$attributeName] = $attributeValue;
+            }
+        }
+
+        // recalculate styles based on sub keys from classes e.g. padding:0; should
+        // override padding-top:10px; set by previous classes
+        foreach (array_keys($newStyles) as $newAttribute) {
+            foreach (array_keys($oldStyles) as $oldAttribute) {
+                // if a old attribute starts with the new attribute key then remove it from the old styles
+                if ($newAttribute === '' || strrpos($oldAttribute, $newAttribute, -strlen($oldAttribute)) !== false) {
+                    unset($oldStyles[$oldAttribute]);
+                }
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ calling the `emogrify` method:
   method to remove media types that Emogrifier keeps.
 * `$emogrifier->addExcludedSelector(string $selector)` - Keeps elements from
   being affected by emogrification.
-
+* `$emogrifier->appendStylesToHead()` - By default, Emogrifier stores any styles in the top of the body
+  using this option it will instead be stored at the bottom of the head.
+* `$emogrifier->disableBackupCssNode()` - By default, Emogrifier Stores a copy of the CSS that was inlined
+  into a style node, if you don't want this you can disable it with this method.
 
 ## Requirements
 
@@ -164,6 +167,9 @@ The following selectors are not implemented yet:
 * Emogrifier now preserves all valuable @media queries. Media queries
   can be very useful in responsive email design. See
   [media query support](https://litmus.com/help/email-clients/media-query-support/).
+* Emogrifier now preserves all stateful selectors e.g. :hover, :active, :link and :visited queries
+  which can be useful to bring interactive elements to email designs.
+* Emogrifier can work with namespaced override and apply the correct ones e.g. padding should override previous padding-top.  
 * Emogrifier will grab existing inline style attributes _and_ will
   grab `<style>` blocks from your HTML, but it will not grab CSS files
   referenced in <link> elements. (The problem email clients are going to ignore

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1907,6 +1907,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
                 '.test { padding: 1px; padding-top: 10px; } .test-p { padding : 2px; }',
                 '<p class="test test-p" style="padding: 2px;">'
             ],
+            'padding class inverted' => [
+                '.test-p { padding : 2px; } .test { padding: 1px; padding-top: 10px; }',
+                '<p class="test test-p" style="padding: 2px;">'
+            ],
             'padding-top !important' => [
                 '.test { padding: 1px; padding-top: 10px !important; } .test-p { padding : 2px; }',
                 '<p class="test test-p" style="padding: 2px; padding-top: 10px !important;">'
@@ -1955,7 +1959,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function emogrifierAddsCssStylesAsStyleNode()
+    public function emogrifierAddsCopyOfCssStylesAsStyleNode()
     {
         $this->subject->appendStylesToHead();
         $this->subject->setCss(

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -954,6 +954,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyFiltersUnneededCssThings($css, $markerNotExpectedInHtml)
     {
         $html = $this->html5DocumentType . '<html><p>foo</p></html>';
+        $this->subject->disableBackupCssNode();
         $this->subject->setHtml($html);
         $this->subject->setCss($css);
 
@@ -1006,6 +1007,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $html = $this->html5DocumentType . '<html></html>';
         $this->subject->setHtml($html);
         $this->subject->setCss($css);
+        $this->subject->disableBackupCssNode();
         $this->subject->removeAllowedMediaType('screen');
 
         $result = $this->subject->emogrify();
@@ -1063,6 +1065,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyKeepExistingHeadElementAddStyleElement()
     {
         $html = $this->html5DocumentType . '<html><head><!-- original content --></head></html>';
+        $this->subject->appendStylesToHead();
         $this->subject->setHtml($html);
         $this->subject->setCss('@media all { html {} }');
 
@@ -1184,6 +1187,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyWithInvalidMediaQueryaNotContainsInnerCss($css)
     {
         $html = $this->html5DocumentType . PHP_EOL . '<html><h1></h1></html>';
+        $this->subject->disableBackupCssNode();
         $this->subject->setHtml($html);
         $this->subject->setCss($css);
 
@@ -1221,6 +1225,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         $html = $this->html5DocumentType . PHP_EOL . '<html><style type="text/css">' . $css .
             '</style><h1></h1></html>';
+        $this->subject->disableBackupCssNode();
         $this->subject->setHtml($html);
 
         $result = $this->subject->emogrify();
@@ -1723,6 +1728,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emptyMediaQueriesAreRemoved()
     {
         $emptyQuery = '@media all and (max-width: 500px) { }';
+        $this->subject->disableBackupCssNode();
         $this->subject->setCss($emptyQuery);
         $this->subject->setHtml($this->html5DocumentType . '<html><body><p></p></body></html>');
 

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1913,4 +1913,68 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             ],
         ];
     }
+
+    /**
+     * @test
+     */
+    public function emogrifierAddsStylesToBody()
+    {
+        $this->subject->setCss(
+            'p { color: blue; }'
+        );
+        $this->subject->setHtml(
+            $this->html5DocumentType . '<html><body><p></p></body></html>'
+        );
+
+        $result = $this->subject->emogrify();
+
+        self::assertContains("<body>\n<style type=\"text/css\">", $result);
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifierAddsStylesToHead()
+    {
+        $this->subject->appendStylesToHead();
+        $this->subject->setCss(
+            'p { color: blue; }'
+        );
+        $this->subject->setHtml(
+            $this->html5DocumentType . '<html><body><p></p></body></html>'
+        );
+
+        $result = $this->subject->emogrify();
+
+        self::assertContains(
+            "<style type=\"text/css\">p { color: blue; }</style>\n</head>",
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifierAddsCssStylesAsStyleNode()
+    {
+        $this->subject->appendStylesToHead();
+        $this->subject->setCss(
+            'p { color: blue; }'
+        );
+        $this->subject->setHtml(
+            $this->html5DocumentType .
+            '<html><body><style type="text/css">p { padding: 10px; }</style><p></p></body></html>'
+        );
+
+        $result = $this->subject->emogrify();
+
+        self::assertContains(
+            'p { color: blue; }',
+            $result
+        );
+        self::assertContains(
+            'p { padding: 10px; }',
+            $result
+        );
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
         {
             "name": "Roman Ožana",
             "email": "ozana@omdesign.cz"
+        },
+        {
+            "name": "Peter Fox",
+            "email": "peter.fox@peterfox.me"
         }
     ],
     "require": {


### PR DESCRIPTION
I was working for a company that needed a PHP library that worked in a similar way to https://github.com/premailer/premailer so I made a few changes to the existing library.

I added a few features (and accompanying tests) that work quite well.

State Selector filtering - Copies all uses of :hover, :active, :visited and :link selectors into it's own style node preserving them

Namespace overrides - If you apply classes to a node and one has .padding-top :10px and the next has padding: 5px; it should actually remove the padding-top:10px by how most CSS processing behaves.

Add Style nodes to Body - Some email clients will ignore style nodes in the head and therefore it's better to store them inside the body by default and set adding to the head as a secondary option.

Add a copy of CSS to the document - Some email clients still use CSS over inlined styles so it's nice to have it but there is also an option to turn it off.

Currently using my modified version in https://github.com/peterfox/php-inliner and it would be nice to lock these features down in the original repo if possible.