### PR TITLE
"!important" style tag fix

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -668,7 +668,9 @@ class Emogrifier
 
         foreach ($oldStyles as $attributeName => $attributeValue) {
             if (isset($newStyles[$attributeName]) && strtolower(substr($attributeValue, -10)) === '!important') {
-                $combinedStyles[$attributeName] = $attributeValue;
+                if (strtolower(substr($newStyles[$attributeName], -10)) !== '!important') {
+                    $combinedStyles[$attributeName] = $attributeValue;
+                }
             }
         }
 

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -1614,6 +1614,24 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function secondImportantStyleTagShouldOverwriteFirstOne()
+    {
+        $css = 'p { margin: 1px !important; } p { margin: 2px !important; }';
+        $html = $this->html5DocumentType .
+            '<html><head</head><body><p>some content</p></body></html>';
+        $expected = '<p style="margin: 2px !important;">';
+        $this->subject->setHtml($html);
+        $this->subject->setCss($css);
+
+        self::assertContains(
+            $expected,
+            $this->subject->emogrify()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function irrelevantMediaQueriesAreRemoved()
     {
         $uselessQuery = '@media all and (max-width: 500px) { em { color:red; } }';


### PR DESCRIPTION
I've found something that looks like a bug.

```html
<html>
<head>
    <style>
    p { margin: 1px !important; }
    p { margin: 2px !important; }
    </style>
</head>
<body>
    <p>Text here</p>
</body>
</html>
```
After precessing with emogrifier it turns into:

```html
<!DOCTYPE html>
<html>
<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>
<body>
    <p style="margin: 1px !important;">Text here</p>
</body>
</html>
```

So i've made quick fix and added one more test. Hope it was helpful to you.