### PR TITLE
[TASK] Skip PHP_CodeSniffer on PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,17 @@ env:
   global:
     secure: nOIIWvxRsDlkg+5H21dmVeqvFbweOAk3l3ZiyZO1m5XuGuuZR9yj10oOudee8m0hzJ7e9eoZ+dfB3t8lmK0fTRTB6w0G7RuGiQb89ief3Zhs1vOveYOgS5yfTMRym57iluxsLeCe7AxWmy7+0fWAvx1qL7bKp+THGK9yv/aj9eM=
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
-
 matrix:
-  allow_failures:
-    - fast_finish: true
-    - php: 7.0
+  include:
+  - php: 5.4
+    env: CODE_SNIFFER=yes
+  - php: 5.5
+    env: CODE_SNIFFER=yes
+  - php: 5.6
+    env: CODE_SNIFFER=yes
+  - php: 7.0
+  - php: hhvm
+    env: CODE_SNIFFER=yes
 
 before_script:
   - composer install
@@ -31,6 +31,6 @@ script:
   # Run PHP lint on all PHP files.
   - find Classes/ Tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
   # Check the coding style.
-  - vendor/bin/phpcs --standard=Configuration/PhpCodeSniffer/Standards/Emogrifier/ Classes/ Tests/
+  - if [[ "CODE_SNIFFER" == "yes" ]]; then vendor/bin/phpcs --standard=Configuration/PhpCodeSniffer/Standards/Emogrifier/ Classes/ Tests/; fi
   # Run the unit tests.
   - vendor/bin/phpunit Tests/


### PR DESCRIPTION
Currently, the code sniffer will not execture on PHP 7 as it fails to load
the sniffs from the TYPO3 sniff pool. Instead of allowing the PHP 7 build
to fail, we now skip the code sniffer for PHP 7, still allowing the linter
and unit tests to run with PHP 7.

Fixes #289