### PR TITLE
Removed references to mbstring dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Removed
+- Removed composer dependency from PHP mbstring extension
+  (Actual code dependency were removed a lot of time ago)
 
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ calling the `emogrify` method:
 
 ## Requirements
 
-* PHP from 5.4 to 7.0 (with the mbstring extension)
+* PHP from 5.4 to 7.0
 * or HHVM
 
 

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "ext-mbstring": "*"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "2.3.4",


### PR DESCRIPTION
Updated composer, Readme and changelog to reflect the fact that mbstring is no longer a dependency.