### PR TITLE
[FEATURE] Added general sibling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.1.0 (unreleased)
 
 ### Added
+- Add support for the general sibling combinator
+  ([#302](https://github.com/jjriv/emogrifier/pull/302))
 - Add CSS to HTML attribute mapper
   ([#288](https://github.com/jjriv/emogrifier/pull/288))
 

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -162,6 +162,8 @@ class Emogrifier
         '/\\s+>\\s+/'                              => '/',
         // adjacent sibling
         '/\\s+\\+\\s+/'                            => '/following-sibling::*[1]/self::',
+        // general sibling
+        '/\\s+\\~\\s+/'                            => '/following-sibling::*/self::',
         // descendant
         '/\\s+/'                                   => '//',
         // :first-child

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Emogrifier currently support the following
  * attribute only
  * first-child
  * last-child
+ * [general sibling combinator](https://www.w3.org/wiki/CSS/Selectors/combinators/general)
 
 The following selectors are not implemented yet:
 

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -578,6 +578,29 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
                 => ['p + p {' . $styleRule . '} ', '#<p class="p-2" style="' . $styleRule . '">#'],
             'adjacent selector P + P matches third P'
                 => ['p + p {' . $styleRule . '} ', '#<p class="p-3" style="' . $styleRule . '">#'],
+            'general selector P ~ P not matches first P' => ['p ~ p {' . $styleRule . '} ', '#<p class="p-1">#'],
+            'general selector P ~ P matches second P' =>
+                ['p ~ p {' . $styleRule . '} ', '#<p class="p-2" style="' . $styleRule . '">#'],
+            'general selector P ~ P matches third P' =>
+                ['p ~ p {' . $styleRule . '} ', '#<p class="p-3" style="' . $styleRule . '">#'],
+            'general selector .P-1 ~ P not matches first P' =>
+                ['.p-1 ~ p {' . $styleRule . '} ', '#<p class="p-1">#'],
+            'general selector .P-1 ~ P matches second P' =>
+                ['.p-1 ~ p {' . $styleRule . '} ', '#<p class="p-2" style="' . $styleRule . '">#'],
+            'general selector .P-1 ~ P matches third P' =>
+                ['.p-1 ~ p {' . $styleRule . '} ', '#<p class="p-3" style="' . $styleRule . '">#'],
+            'general selector .P-2 ~ P not matches first P'    =>
+                ['.p-2 ~ p {' . $styleRule . '} ', '#<p class="p-1">#'],
+            'general selector .P-2 ~ P not matches second P'    =>
+                ['.p-2 ~ p {' . $styleRule . '} ', '#<p class="p-2">#'],
+            'general selector .P-2 ~ P matches third P'    =>
+                ['.p-2 ~ p {' . $styleRule . '} ', '#<p class="p-3" style="' . $styleRule . '">#'],
+            'general selector .P-3 ~ P not matches first P'    =>
+                ['.p-3 ~ p {' . $styleRule . '} ', '#<p class="p-1">#'],
+            'general selector .P-3 ~ P not matches second P'    =>
+                ['.p-3 ~ p {' . $styleRule . '} ', '#<p class="p-2">#'],
+            'general selector .P-3 ~ P not matches third P'    =>
+                ['.p-3 ~ p {' . $styleRule . '} ', '#<p class="p-3">#'],
             'ID selector #HTML' => ['#html {' . $styleRule . '} ', '#<html id="html" ' . $styleAttribute . '>#'],
             'type and ID selector HTML#HTML'
                 => ['html#html {' . $styleRule . '} ', '#<html id="html" ' . $styleAttribute . '>#'],


### PR DESCRIPTION
This pull request was made for the issue #301

I made some smoketests for the new rule: 

**index.php**
```
<?php

require __DIR__ . '/../vendor/autoload.php';

$emogrifier = new Pelago\Emogrifier();

$emogrifier->setCss(file_get_contents(__DIR__ . '/test.css'));
$emogrifier->setHtml(file_get_contents(__DIR__ . '/test.html'));

print $emogrifier->emogrify();
```

**test.html**
```
<!DOCTYPE html>
<html>
<head lang="en">
    <meta charset="UTF-8">
    <title>Test</title>
</head>
<body>
<div class="hit">Container 0.5</div>
<div class="target">Container 1</div>
<h1>Headline</h1>
<div class="hit">Container 2</div>
<div class="foo">
    <span>Container 3</span>
    <div class="hit">Sub Container 3</div>
</div>
<div class="hit">Container 3.25</div>
<div class="target">Container 3.50</div>
<div class="bar">Container 4</div>
<div class="hit">Container 5</div>
</body>
</html>
```

**test.css**
```
.target ~ .hit {
    background: blue;
}
```

I had rarely to do with xpath in the past. Therefore my xpath-skills are bad. Please test the new rule before you publish it. It has to be compatible with the other modifications which are made in the method `translateCssToXpath`. 