### PR TITLE
[BUG] Ignore pseudo elements when combined with pseudo selector

### DIFF
--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -561,7 +561,7 @@ class Emogrifier
                 foreach ($selectors as $selector) {
                     // don't process pseudo-elements and behavioral (dynamic) pseudo-classes;
                     // only allow structural pseudo-classes
-                    if (strpos($selector, ':') !== false && !preg_match('/:\\S+\\-(child|type\\()/i', $selector)) {
+                    if (strpos($selector, ':') !== false && preg_match('/:(?!\\S+\\-(child|type\\())/i', $selector)) {
                         continue;
                     }
 

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -2066,4 +2066,17 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             $html
         );
     }
+
+    /**
+     * @test
+     */
+    public function emogrifierParsePseudoSelector()
+    {
+        $css = 'div:last-child::after {float: right;}';
+        $this->subject->setHtml($this->html5DocumentType . '<html><body><div></div></body></html>');
+        $this->subject->setCss($css);
+
+        $html = $this->subject->emogrify();
+        self::assertContains('<div></div>', $html);
+    }
 }


### PR DESCRIPTION
Ignores CSS statements of the form `el:pseudoselector:pseudoelement` where pseudoselector is a supported selector such as `:last-child` and pseudoelement is an unsupported selector such as `:after`.