### PR TITLE
[BUGFIX] Ignore pseudo-class when combined with pseudo-element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Fixed
+- Ignore pseudo-class when combined with pseudo-element
+  ([#308](https://github.com/jjriv/emogrifier/pull/308))
 - First-child and last-child selectors are broken
   ([#293](https://github.com/jjriv/emogrifier/pull/293))
 - Second !important rule needs to overwrite the first one

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -561,7 +561,10 @@ class Emogrifier
                 foreach ($selectors as $selector) {
                     // don't process pseudo-elements and behavioral (dynamic) pseudo-classes;
                     // only allow structural pseudo-classes
-                    if (strpos($selector, ':') !== false && !preg_match('/:\\S+\\-(child|type\\()/i', $selector)) {
+                    $hasPseudoElement = strpos($selector, '::') !== false;
+                    $hasAnyPseudoClass = (bool)preg_match('/:[a-zA-Z]/', $selector);
+                    $hasSupportedPseudoClass = (bool)preg_match('/:\\S+\\-(child|type\\()/i', $selector);
+                    if ($hasPseudoElement || ($hasAnyPseudoClass && !$hasSupportedPseudoClass)) {
                         continue;
                     }
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Emogrifier currently support the following
 The following selectors are not implemented yet:
 
  * universal
+ * pseudo-elements (will never be supported)
 
 
 ## Caveats

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -2070,4 +2070,17 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             $html
         );
     }
+
+    /**
+     * @test
+     */
+    public function emogrifierIgnoresPseudoClassCombinedWithPseudoElement()
+    {
+        $css = 'div:last-child::after {float: right;}';
+        $this->subject->setHtml($this->html5DocumentType . '<html><body><div></div></body></html>');
+        $this->subject->setCss($css);
+
+        $html = $this->subject->emogrify();
+        self::assertContains('<div></div>', $html);
+    }
 }


### PR DESCRIPTION
Ignores CSS statements of the form "el:pseudoclass::pseudoelement"
where "pseudoclass" is a supported selector such as ":last-child"
and pseudoelement is an unsupported selector such as "::after".

Fixes #308