### PR TITLE
[BUGFIX] Allow spaces around the > in the direct child selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Fixed
+- Allow spaces around the > in the direct child selector
+  ([#322](https://github.com/jjriv/emogrifier/pull/322))
 - Ignore empty media queries
   ([#307](https://github.com/jjriv/emogrifier/pull/307))
   ([#237](https://github.com/jjriv/emogrifier/issues/237))

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -159,7 +159,7 @@ class Emogrifier
      */
     private $xPathRules = [
         // child
-        '/\\s+>\\s+/'                              => '/',
+        '/\\s*>\\s*/'                              => '/',
         // adjacent sibling
         '/\\s+\\+\\s+/'                            => '/following-sibling::*[1]/self::',
         // descendant

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -570,6 +570,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
                 => ['body span {' . $styleRule . '} ', '#<span ' . $styleAttribute . '>#'],
             'child selector P > SPAN matches direct child'
                 => ['p > span {' . $styleRule . '} ', '#<span ' . $styleAttribute . '>#'],
+            'child selector P > SPAN matches direct child without space after >'
+                => ['p >span {' . $styleRule . '} ', '#<span ' . $styleAttribute . '>#'],
+            'child selector P > SPAN matches direct child without space before >'
+                => ['p> span {' . $styleRule . '} ', '#<span ' . $styleAttribute . '>#'],
             'child selector BODY > SPAN does not match grandchild'
                 => ['body > span {' . $styleRule . '} ', '#<span>#'],
             'adjacent selector P + P does not match first P' => ['p + p {' . $styleRule . '} ', '#<p class="p-1">#'],


### PR DESCRIPTION
This is part of #321.