### PR TITLE
Add style blocks to body rather than head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## x.y.z (unreleased)
 
 ### Added
-
+- Added setting for putting the media query style block to <body> vs <head>
 
 ### Changed
 

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -155,6 +155,17 @@ class Emogrifier
     private $shouldKeepInvisibleNodes = true;
 
     /**
+     * Determines whether media query style blocks should be added to the body versus the head of the HTML.
+     * 
+     * If set to true, the <style> blocks will be added to the <body>
+     * 
+     * If set to false, the <style> blocks will be added to the <head>
+     *
+     * @var bool
+     */
+    private $shouldAddStyleToBody = false;
+
+    /**
      * @var string[]
      */
     private $xPathRules = [
@@ -640,6 +651,16 @@ class Emogrifier
     }
 
     /**
+     * Adds media query styles to <body> instead of <head>
+     *
+     * @return void
+     */
+    public function addStyleToBody()
+    {
+        $this->shouldAddStyleToBody = true;
+    }
+
+    /**
      * Clears all caches.
      *
      * @return void
@@ -1021,8 +1042,20 @@ class Emogrifier
         $styleAttribute->value = 'text/css';
         $styleElement->appendChild($styleAttribute);
 
-        $head = $this->getOrCreateHeadElement($document);
-        $head->appendChild($styleElement);
+        if ($this->shouldAddStyleToBody) {
+            $body = $this->getBodyElement($document);
+            $body->appendChild($styleElement);
+            if ($body->hasChildNodes()) {
+                $body->insertBefore($styleElement,$body->firstChild);
+            }
+            else {
+                $body->appendChild($styleElement);
+            }
+        }
+        else {
+            $head = $this->getOrCreateHeadElement($document);
+            $head->appendChild($styleElement);
+        }
     }
 
     /**
@@ -1043,6 +1076,20 @@ class Emogrifier
         }
 
         return $head;
+    }
+
+    /**
+     * Returns the existing body element in $document.
+     *
+     * @param \DOMDocument $document
+     *
+     * @return \DOMNode the body element
+     */
+    private function getBodyElement(\DOMDocument $document)
+    {
+        $body = $document->getElementsByTagName('body')->item(0);
+
+        return $body;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ calling the `emogrify` method:
   well, even if inline and prefer HTML attributes. This function allows you to
   put properties such as height, width, background color and font color in your
   CSS while the transformed content will have all the available HTML tags set.
+* `$emogrifier->addStyleToBody()` - By default, Emogrifier will append a `<style>`
+  block with all media queries to the `<head>` of the HTML.  If you wand to append
+  it to the top of the `<body>` instead, use this option.  This is useful because many
+  email clients will completely drop the `<head>` block from all emails.
 
 
 ## Requirements


### PR DESCRIPTION
Foundation for Email recommends inlining css into the body rather than head so I added an option to allow for that.