### PR TITLE
[CLEANUP] Simplify the doctype handling in the tests

### DIFF
--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -150,7 +150,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyKeepsDollarSignsAndSquareBrackets()
     {
         $templateMarker = '$[USER:NAME]$';
-        $html = $this->html5DocumentType . '<html><p>' . $templateMarker . '</p></html>';
+        $html = '<html><p>' . $templateMarker . '</p></html>';
         $this->subject->setHtml($html);
 
         $result = $this->subject->emogrify();
@@ -206,7 +206,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyKeepsHtmlEntities()
     {
         $entityString = 'a &amp; b &gt; c';
-        $html = $this->html5DocumentType . '<html><p>' . $entityString . '</p></html>';
+        $html = '<html><p>' . $entityString . '</p></html>';
         $this->subject->setHtml($html);
 
         $result = $this->subject->emogrify();
@@ -234,7 +234,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyKeepsHtmlEntitiesInHtml4()
     {
         $entityString = 'a &amp; b &gt; c';
-        $html = $this->html4TransitionalDocumentType . '<html><p>' . $entityString . '</p></html>';
+        $html = $this->html5DocumentType . '<html><p>' . $entityString . '</p></html>';
         $this->subject->setHtml($html);
 
         $result = $this->subject->emogrify();
@@ -343,8 +343,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyAddsContentTypeMetaTag()
     {
-        $html = $this->html5DocumentType . '<p>Hello</p>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<p>Hello</p>');
 
         $result = $this->subject->emogrify();
 
@@ -356,8 +355,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyForExistingContentTypeMetaTagNotAddsSecondContentTypeMetaTag()
     {
-        $html = $this->html5DocumentType .
-            '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' .
+        $html = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>' .
             '<body><p>Hello</p></body></html>';
         $this->subject->setHtml($html);
 
@@ -371,7 +369,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyByDefaultRemovesWbrTag()
     {
-        $html = $this->html5DocumentType . '<html>foo<wbr/>bar</html>';
+        $html = '<html>foo<wbr/>bar</html>';
         $this->subject->setHtml($html);
 
         $result = $this->subject->emogrify();
@@ -384,8 +382,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function addUnprocessableTagCausesGivenEmptyTagToBeRemoved()
     {
-        $html = $this->html5DocumentType . '<html><p></p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><p></p></html>');
 
         $this->subject->addUnprocessableHtmlTag('p');
         $result = $this->subject->emogrify();
@@ -398,8 +395,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function addUnprocessableTagNotRemovesGivenTagWithContent()
     {
-        $html = $this->html5DocumentType . '<html><p>foobar</p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><p>foobar</p></html>');
 
         $this->subject->addUnprocessableHtmlTag('p');
         $result = $this->subject->emogrify();
@@ -412,8 +408,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function removeUnprocessableHtmlTagCausesTagToStayAgain()
     {
-        $html = $this->html5DocumentType . '<html><p>foo<br/><span>bar</span></p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><p>foo<br/><span>bar</span></p></html>');
 
         $this->subject->addUnprocessableHtmlTag('p');
         $this->subject->removeUnprocessableHtmlTag('p');
@@ -427,8 +422,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyCanAddMatchingElementRuleOnHtmlElementFromCss()
     {
-        $html = $this->html5DocumentType . '<html></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html></html>');
         $styleRule = 'color: #000;';
         $this->subject->setCss('html {' . $styleRule . '}');
 
@@ -445,8 +439,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyNotAddsNotMatchingElementRuleOnHtmlElementFromCss()
     {
-        $html = $this->html5DocumentType . '<html></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html></html>');
         $this->subject->setCss('p {color:#000;}');
 
         $result = $this->subject->emogrify();
@@ -459,8 +452,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyCanMatchTwoElements()
     {
-        $html = $this->html5DocumentType . '<html><p></p><p></p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><p></p><p></p></html>');
         $styleRule = 'color: #000;';
         $this->subject->setCss('p {' . $styleRule . '}');
 
@@ -477,8 +469,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyCanAssignTwoStyleRulesFromSameMatcherToElement()
     {
-        $html = $this->html5DocumentType . '<html><p></p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><p></p></html>');
         $styleRulesIn = 'color:#000; text-align:left;';
         $this->subject->setCss('p {' . $styleRulesIn . '}');
 
@@ -496,8 +487,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyCanMatchAttributeOnlySelector()
     {
-        $html = $this->html5DocumentType . '<html><p hidden="hidden"></p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><p hidden="hidden"></p></html>');
         $this->subject->setCss('[hidden] { color:red; }');
 
         $result = $this->subject->emogrify();
@@ -510,8 +500,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyCanAssignStyleRulesFromTwoIdenticalMatchersToElement()
     {
-        $html = $this->html5DocumentType . '<html><p></p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><p></p></html>');
         $styleRule1 = 'color: #000;';
         $styleRule2 = 'text-align: left;';
         $this->subject->setCss('p {' . $styleRule1 . '}  p {' . $styleRule2 . '}');
@@ -529,8 +518,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyCanAssignStyleRulesFromTwoDifferentMatchersToElement()
     {
-        $html = $this->html5DocumentType . '<html><p class="x"></p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><p class="x"></p></html>');
         $styleRule1 = 'color: #000;';
         $styleRule2 = 'text-align: left;';
         $this->subject->setCss('p {' . $styleRule1 . '} .x {' . $styleRule2 . '}');
@@ -689,8 +677,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifierMatchesSelectors($css, $htmlRegularExpression)
     {
-        $html = $this->html5DocumentType .
-            '<html id="html">' .
+        $html =  '<html id="html">' .
             '  <body>' .
             '    <p class="p-1"><span>some text</span></p>' .
             '    <p class="p-2"><span title="bonjour">some</span> text</p>' .
@@ -744,10 +731,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
         $cssDeclaration,
         $expectedStyleAttributeContent
     ) {
-        $html = $this->html5DocumentType . '<html></html>';
-        $css = 'html {' . $cssDeclaration . '}';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html></html>');
+        $this->subject->setCss('html {' . $cssDeclaration . '}');
 
         $result = $this->subject->emogrify();
 
@@ -793,10 +778,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyFormatsCssDeclarations($cssDeclarationBlock, $expectedStyleAttributeContent)
     {
-        $html = $this->html5DocumentType . '<html></html>';
-        $css = 'html {' . $cssDeclarationBlock . '}';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html></html>');
+        $this->subject->setCss('html {' . $cssDeclarationBlock . '}');
 
         $result = $this->subject->emogrify();
 
@@ -830,10 +813,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyDropsInvalidDeclaration($cssDeclarationBlock)
     {
-        $html = $this->html5DocumentType . '<html></html>';
-        $css = 'html {' . $cssDeclarationBlock . '}';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html></html>');
+        $this->subject->setCss('html {' . $cssDeclarationBlock . '}');
 
         $result = $this->subject->emogrify();
 
@@ -846,8 +827,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyKeepsExistingStyleAttributes()
     {
         $styleAttribute = 'style="color: #ccc;"';
-        $html = $this->html5DocumentType . '<html ' . $styleAttribute . '></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html ' . $styleAttribute . '></html>');
 
         $result = $this->subject->emogrify();
 
@@ -860,8 +840,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyAddsCssAfterExistingStyle()
     {
         $styleAttributeValue = 'color: #ccc;';
-        $html = $this->html5DocumentType . '<html style="' . $styleAttributeValue . '"></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html style="' . $styleAttributeValue . '"></html>');
         $cssDeclarations = 'margin: 0 2px;';
         $css = 'html {' . $cssDeclarations . '}';
         $this->subject->setCss($css);
@@ -879,8 +858,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyCanMatchMinifiedCss()
     {
-        $html = $this->html5DocumentType . '<html><p></p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><p></p></html>');
         $this->subject->setCss('p{color:blue;}html{color:red;}');
 
         $result = $this->subject->emogrify();
@@ -893,8 +871,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyLowercasesAttributeNamesFromStyleAttributes()
     {
-        $html = $this->html5DocumentType . '<html style="COLOR:#ccc;"></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html style="COLOR:#ccc;"></html>');
 
         $result = $this->subject->emogrify();
 
@@ -906,10 +883,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyLowerCasesAttributeNames()
     {
-        $html = $this->html5DocumentType . '<html></html>';
-        $this->subject->setHtml($html);
-        $cssIn = 'html {mArGiN:0 2pX;}';
-        $this->subject->setCss($cssIn);
+        $this->subject->setHtml('<html></html>');
+        $this->subject->setCss('html {mArGiN:0 2pX;}');
 
         $result = $this->subject->emogrify();
 
@@ -921,15 +896,14 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyPreservesCaseForAttributeValuesFromPassedInCss()
     {
-        $css = 'content: \'Hello World\';';
-        $html = $this->html5DocumentType . '<html><body><p>target</p></body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss('p {' . $css . '}');
+        $cssDeclaration = 'content: \'Hello World\';';
+        $this->subject->setHtml('<html><body><p>target</p></body></html>');
+        $this->subject->setCss('p {' . $cssDeclaration . '}');
 
         $result = $this->subject->emogrify();
 
         self::assertContains(
-            '<p style="' . $css . '">target</p>',
+            '<p style="' . $cssDeclaration . '">target</p>',
             $result
         );
     }
@@ -939,15 +913,15 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyPreservesCaseForAttributeValuesFromParsedStyleBlock()
     {
-        $css = 'content: \'Hello World\';';
-        $html = $this->html5DocumentType . '<html><head><style>p {' .
-            $css . '}</style></head><body><p>target</p></body></html>';
-        $this->subject->setHtml($html);
+        $cssDeclaration = 'content: \'Hello World\';';
+        $this->subject->setHtml(
+            '<html><head><style>p {' . $cssDeclaration . '}</style></head><body><p>target</p></body></html>'
+        );
 
         $result = $this->subject->emogrify();
 
         self::assertContains(
-            '<p style="' . $css . '">target</p>',
+            '<p style="' . $cssDeclaration . '">target</p>',
             $result
         );
     }
@@ -957,8 +931,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyRemovesStyleNodes()
     {
-        $html = $this->html5DocumentType . '<html><style type="text/css"></style></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><style type="text/css"></style></html>');
 
         $result = $this->subject->emogrify();
 
@@ -970,17 +943,17 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      *
      * @expectedException \InvalidArgumentException
      */
-    public function emogrifyFailsOnInvalidCssSelector()
+    public function emogrifyForInvalidCssSelectorThrowsException()
     {
-        // HHVM ignore custom error handler settings for libxml
+        // HHVM ignores custom error handler settings for libxml.
         // @see https://github.com/facebook/hhvm/issues/5790
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped('HHVM ignore custom error handler');
         }
 
-        $html = $this->html5DocumentType .
-            '<html><style type="text/css">p{color:red;} <style data-x="1">html{cursor:text;}</style></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml(
+            '<html><style type="text/css">p{color:red;} <style data-x="1">html{cursor:text;}</style></html>'
+        );
 
         $this->subject->emogrify();
     }
@@ -1017,8 +990,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyFiltersUnneededCssThings($css, $markerNotExpectedInHtml)
     {
-        $html = $this->html5DocumentType . '<html><p>foo</p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><p>foo</p></html>');
         $this->subject->setCss($css);
 
         $result = $this->subject->emogrify();
@@ -1052,8 +1024,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyKeepsMediaRules($css)
     {
-        $html = $this->html5DocumentType . '<html><p>foo</p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><p>foo</p></html>');
         $this->subject->setCss($css);
 
         $result = $this->subject->emogrify();
@@ -1067,8 +1038,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function removeAllowedMediaTypeRemovesStylesForTheGivenMediaType()
     {
         $css = '@media screen { html {} }';
-        $html = $this->html5DocumentType . '<html></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html></html>');
         $this->subject->setCss($css);
         $this->subject->removeAllowedMediaType('screen');
 
@@ -1083,8 +1053,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function addAllowedMediaTypeKeepsStylesForTheGivenMediaType()
     {
         $css = '@media braille { html { some-property: value; } }';
-        $html = $this->html5DocumentType . '<html></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html></html>');
         $this->subject->setCss($css);
         $this->subject->addAllowedMediaType('braille');
 
@@ -1098,8 +1067,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyAddsMissingHeadElement()
     {
-        $html = $this->html5DocumentType . '<html></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html></html>');
         $this->subject->setCss('@media all { html {} }');
 
         $result = $this->subject->emogrify();
@@ -1112,8 +1080,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyKeepExistingHeadElementContent()
     {
-        $html = $this->html5DocumentType . '<html><head><!-- original content --></head></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><head><!-- original content --></head></html>');
         $this->subject->setCss('@media all { html {} }');
 
         $result = $this->subject->emogrify();
@@ -1175,8 +1142,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyWithValidMediaQueryContainsInnerCss($css)
     {
-        $html = $this->html5DocumentType . PHP_EOL . '<html><h1></h1><p></p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><h1></h1><p></p></html>');
         $this->subject->setCss($css);
 
         $result = $this->subject->emogrify();
@@ -1193,9 +1159,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyForHtmlWithValidMediaQueryContainsInnerCss($css)
     {
-        $html = $this->html5DocumentType . PHP_EOL . '<html><style type="text/css">' . $css .
-            '</style><h1></h1><p></p></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><style type="text/css">' . $css . '</style><h1></h1><p></p></html>');
 
         $result = $this->subject->emogrify();
 
@@ -1211,8 +1175,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyWithValidMediaQueryNotContainsInlineCss($css)
     {
-        $html = $this->html5DocumentType . PHP_EOL . '<html><h1></h1></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><h1></h1></html>');
         $this->subject->setCss($css);
 
         $result = $this->subject->emogrify();
@@ -1247,8 +1210,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyWithInvalidMediaQueryNotContainsInnerCss($css)
     {
-        $html = $this->html5DocumentType . PHP_EOL . '<html><h1></h1></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><h1></h1></html>');
         $this->subject->setCss($css);
 
         $result = $this->subject->emogrify();
@@ -1265,8 +1227,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyWithInValidMediaQueryNotContainsInlineCss($css)
     {
-        $html = $this->html5DocumentType . PHP_EOL . '<html><h1></h1></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><h1></h1></html>');
         $this->subject->setCss($css);
 
         $result = $this->subject->emogrify();
@@ -1283,9 +1244,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyFromHtmlWithInValidMediaQueryNotContainsInnerCss($css)
     {
-        $html = $this->html5DocumentType . PHP_EOL . '<html><style type="text/css">' . $css .
-            '</style><h1></h1></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><style type="text/css">' . $css . '</style><h1></h1></html>');
 
         $result = $this->subject->emogrify();
 
@@ -1301,9 +1260,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyFromHtmlWithInValidMediaQueryNotContainsInlineCss($css)
     {
-        $html = $this->html5DocumentType . PHP_EOL . '<html><style type="text/css">' . $css .
-            '</style><h1></h1></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><style type="text/css">' . $css . '</style><h1></h1></html>');
 
         $result = $this->subject->emogrify();
 
@@ -1315,10 +1272,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyIgnoresEmptyMediaQuery()
     {
-        $css = '@media screen {} @media tv { h1 { color: red; } }';
-        $html = $this->html5DocumentType . PHP_EOL . '<html><h1></h1></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html><h1></h1></html>');
+        $this->subject->setCss('@media screen {} @media tv { h1 { color: red; } }');
 
         $result = $this->subject->emogrify();
 
@@ -1331,10 +1286,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyIgnoresMediaQueryWithWhitespaceOnly()
     {
-        $css = '@media screen { } @media tv { h1 { color: red; } }';
-        $html = $this->html5DocumentType . PHP_EOL . '<html><h1></h1></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html><h1></h1></html>');
+        $this->subject->setCss('@media screen { } @media tv { h1 { color: red; } }');
 
         $result = $this->subject->emogrify();
 
@@ -1348,9 +1301,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyAppliesCssFromStyleNodes()
     {
         $styleAttributeValue = 'color: #ccc;';
-        $html = $this->html5DocumentType .
-            '<html><style type="text/css">html {' . $styleAttributeValue . '}</style></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><style type="text/css">html {' . $styleAttributeValue . '}</style></html>');
 
         $result = $this->subject->emogrify();
 
@@ -1366,9 +1317,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyWhenDisabledNotAppliesCssFromStyleBlocks()
     {
         $styleAttributeValue = 'color: #ccc;';
-        $html = $this->html5DocumentType .
-            '<html><style type="text/css">html {' . $styleAttributeValue . '}</style></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html><style type="text/css">html {' . $styleAttributeValue . '}</style></html>');
         $this->subject->disableStyleBlocksParsing();
 
         $result = $this->subject->emogrify();
@@ -1385,9 +1334,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyWhenStyleBlocksParsingDisabledKeepInlineStyles()
     {
         $styleAttributeValue = 'text-align: center;';
-        $html = $this->html5DocumentType . '<html><head><style type="text/css">p { color: #ccc; }</style></head>' .
-            '<body><p style="' . $styleAttributeValue . '">paragraph</p></body></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml(
+            '<html><head><style type="text/css">p { color: #ccc; }</style></head>' .
+            '<body><p style="' . $styleAttributeValue . '">paragraph</p></body></html>'
+        );
         $this->subject->disableStyleBlocksParsing();
 
         $result = $this->subject->emogrify();
@@ -1403,9 +1353,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyWhenDisabledNotAppliesCssFromInlineStyles()
     {
-        $styleAttributeValue = 'color: #ccc;';
-        $html = $this->html5DocumentType . '<html style="' . $styleAttributeValue . '"></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html style="color: #ccc;"></html>');
         $this->subject->disableInlineStyleAttributesParsing();
 
         $result = $this->subject->emogrify();
@@ -1419,10 +1367,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyWhenInlineStyleAttributesParsingDisabledKeepStyleBlockStyles()
     {
         $styleAttributeValue = 'color: #ccc;';
-        $html = $this->html5DocumentType .
+        $this->subject->setHtml(
             '<html><head><style type="text/css">p { ' . $styleAttributeValue . ' }</style></head>' .
-            '<body><p style="text-align: center;">paragraph</p></body></html>';
-        $this->subject->setHtml($html);
+            '<body><p style="text-align: center;">paragraph</p></body></html>'
+        );
         $this->subject->disableInlineStyleAttributesParsing();
 
         $result = $this->subject->emogrify();
@@ -1438,9 +1386,9 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyAppliesCssWithUpperCaseSelector()
     {
-        $html = $this->html5DocumentType .
-            '<html><style type="text/css">P { color:#ccc; }</style><body><p>paragraph</p></body></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml(
+            '<html><style type="text/css">P { color:#ccc; }</style><body><p>paragraph</p></body></html>'
+        );
 
         $result = $this->subject->emogrify();
 
@@ -1453,10 +1401,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyAppliesCssWithMixedCaseAttributesInStyleBlock()
     {
-        $html = $this->html5DocumentType .
+        $this->subject->setHtml(
             '<html><head><style>#topWrap p {padding-bottom: 1px;PADDING-TOP: 0;}</style></head>' .
-            '<body><div id="topWrap"><p style="text-align: center;">some content</p></div></body></html>';
-        $this->subject->setHtml($html);
+            '<body><div id="topWrap"><p style="text-align: center;">some content</p></div></body></html>'
+        );
 
         $result = $this->subject->emogrify();
 
@@ -1469,12 +1417,11 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyMergesCssWithMixedCaseAttribute()
     {
-        $css = 'p { margin: 0; padding-TOP: 0; PADDING-bottom: 1PX;}';
-        $html = $this->html5DocumentType .
+        $this->subject->setHtml(
             '<html><head><style>#topWrap p {padding-bottom: 3px;PADDING-TOP: 1px;}</style></head>' .
-            '<body><div id="topWrap"><p style="text-align: center;">some content</p></div></body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+            '<body><div id="topWrap"><p style="text-align: center;">some content</p></div></body></html>'
+        );
+        $this->subject->setCss('p { margin: 0; padding-TOP: 0; PADDING-bottom: 1PX;}');
 
         $result = $this->subject->emogrify();
 
@@ -1489,12 +1436,11 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyMergesCssWithMixedUnits()
     {
-        $css = 'p { margin: 1px; padding-bottom:0;}';
-        $html = $this->html5DocumentType .
+        $this->subject->setHtml(
             '<html><head><style>#topWrap p {margin:0;padding-bottom: 1px;}</style></head>' .
-            '<body><div id="topWrap"><p style="text-align: center;">some content</p></div></body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+            '<body><div id="topWrap"><p style="text-align: center;">some content</p></div></body></html>'
+        );
+        $this->subject->setCss('p { margin: 1px; padding-bottom:0;}');
 
         $result = $this->subject->emogrify();
 
@@ -1506,10 +1452,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyByDefaultRemovesElementsWithDisplayNoneFromExternalCss()
     {
-        $css = 'div.foo { display: none; }';
-        $html = $this->html5DocumentType . '<html><body><div class="bar"></div><div class="foo"></div></body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html><body><div class="bar"></div><div class="foo"></div></body></html>');
+        $this->subject->setCss('div.foo { display: none; }');
 
         $result = $this->subject->emogrify();
 
@@ -1521,10 +1465,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyByDefaultRemovesElementsWithDisplayNoneInStyleAttribute()
     {
-        $html = $this->html5DocumentType .
+        $this->subject->setHtml(
             '<html><body><div class="bar"></div><div class="foobar" style="display: none;"></div>' .
-            '</body></html>';
-        $this->subject->setHtml($html);
+            '</body></html>'
+        );
 
         $result = $this->subject->emogrify();
 
@@ -1536,12 +1480,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyAfterDisableInvisibleNodeRemovalPreservesInvisibleElements()
     {
-        $css = 'div.foo { display: none; }';
-        $html = $this->html5DocumentType . '<html><body><div class="bar"></div><div class="foo"></div></body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
-        $this->subject->disableInvisibleNodeRemoval();
+        $this->subject->setHtml('<html><body><div class="bar"></div><div class="foo"></div></body></html>');
+        $this->subject->setCss('div.foo { display: none; }');
 
+        $this->subject->disableInvisibleNodeRemoval();
         $result = $this->subject->emogrify();
 
         self::assertContains('<div class="foo" style="display: none;">', $result);
@@ -1552,10 +1494,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyKeepsCssMediaQueriesWithCssCommentAfterMediaQuery()
     {
-        $css = '@media only screen and (max-width: 480px) { body { color: #ffffff } /* some comment */ }';
-        $html = $this->html5DocumentType . '<html><body></body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html><body></body></html>');
+        $this->subject->setCss(
+            '@media only screen and (max-width: 480px) { body { color: #ffffff } /* some comment */ }'
+        );
 
         $result = $this->subject->emogrify();
 
@@ -1603,7 +1545,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyAutomaticallyClosesUnclosedTag()
     {
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><p></body></html>');
+        $this->subject->setHtml('<html><body><p></body></html>');
 
         $result = $this->subject->emogrify();
 
@@ -1615,7 +1557,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyReturnsCompleteHtmlDocument()
     {
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><p></p></body></html>');
+        $this->subject->setHtml('<html><body><p></p></body></html>');
 
         $result = $this->subject->emogrify();
 
@@ -1634,7 +1576,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyBodyContentReturnsBodyContentFromHtml()
     {
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><p></p></body></html>');
+        $this->subject->setHtml('<html><body><p></p></body></html>');
 
         $result = $this->subject->emogrifyBodyContent();
 
@@ -1665,8 +1607,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     public function emogrifyBodyContentKeepsUtf8Umlauts()
     {
         $umlautString = 'Küss die Hand, schöne Frau.';
-        $html = '<p>' . $umlautString . '</p>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<p>' . $umlautString . '</p>');
 
         $result = $this->subject->emogrifyBodyContent();
 
@@ -1678,11 +1619,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function importantInExternalCssOverwritesInlineCss()
     {
-        $css = 'p { margin: 1px !important; }';
-        $html = $this->html5DocumentType .
-            '<html><head</head><body><p style="margin: 2px;">some content</p></body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html><head</head><body><p style="margin: 2px;">some content</p></body></html>');
+        $this->subject->setCss('p { margin: 1px !important; }');
 
         $result = $this->subject->emogrify();
 
@@ -1694,11 +1632,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function importantInExternalCssKeepsInlineCssForOtherAttributes()
     {
-        $css = 'p { margin: 1px !important; }';
-        $html = $this->html5DocumentType .
-            '<html><head</head><body><p style="margin: 2px; text-align: center;">some content</p></body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml(
+            '<html><head</head><body><p style="margin: 2px; text-align: center;">some content</p></body></html>'
+        );
+        $this->subject->setCss('p { margin: 1px !important; }');
 
         $result = $this->subject->emogrify();
 
@@ -1710,11 +1647,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyHandlesImportantStyleTagCaseInsensitive()
     {
-        $css = 'p { margin: 1px !ImPorTant; }';
-        $html = $this->html5DocumentType .
-            '<html><head</head><body><p style="margin: 2px;">some content</p></body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html><head</head><body><p style="margin: 2px;">some content</p></body></html>');
+        $this->subject->setCss('p { margin: 1px !ImPorTant; }');
 
         $result = $this->subject->emogrify();
 
@@ -1726,11 +1660,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function secondImportantStyleOverwritesFirstOne()
     {
-        $css = 'p { margin: 1px !important; } p { margin: 2px !important; }';
-        $html = $this->html5DocumentType .
-            '<html><head</head><body><p>some content</p></body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html><head</head><body><p>some content</p></body></html>');
+        $this->subject->setCss('p { margin: 1px !important; } p { margin: 2px !important; }');
 
         $result = $this->subject->emogrify();
 
@@ -1745,11 +1676,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function secondNonImportantStyleOverwritesFirstOne()
     {
-        $css = 'p { margin: 1px; } p { margin: 2px; }';
-        $html = $this->html5DocumentType .
-            '<html><head</head><body><p>some content</p></body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html><head</head><body><p>some content</p></body></html>');
+        $this->subject->setCss('p { margin: 1px; } p { margin: 2px; }');
 
         $result = $this->subject->emogrify();
 
@@ -1764,11 +1692,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function secondNonImportantStyleNotOverwritesFirstImportantOne()
     {
-        $css = 'p { margin: 1px !important; } p { margin: 2px; }';
-        $html = $this->html5DocumentType .
-            '<html><head</head><body><p>some content</p></body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html><head</head><body><p>some content</p></body></html>');
+        $this->subject->setCss('p { margin: 1px !important; } p { margin: 2px; }');
 
         $result = $this->subject->emogrify();
 
@@ -1785,7 +1710,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         $uselessQuery = '@media all and (max-width: 500px) { em { color:red; } }';
         $this->subject->setCss($uselessQuery);
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><p></p></body></html>');
+        $this->subject->setHtml('<html><body><p></p></body></html>');
 
         $result = $this->subject->emogrify();
 
@@ -1799,7 +1724,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         $usefulQuery = '@media all and (max-width: 500px) { p { color:red; } }';
         $this->subject->setCss($usefulQuery);
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><p></p></body></html>');
+        $this->subject->setHtml('<html><body><p></p></body></html>');
 
         $result = $this->subject->emogrify();
 
@@ -1811,12 +1736,12 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function importantStyleRuleFromInlineCssOverwritesImportantStyleRuleFromExternalCss()
     {
-        $css = 'p { margin: 1px !important; padding: 1px;}';
-        $html = $this->html5DocumentType .
-            '<html><head</head><body><p style="margin: 2px !important; text-align: center;">some content</p>' .
-            '</body></html>';
-        $this->subject->setHtml($html);
-        $this->subject->setCss($css);
+        $this->subject->setHtml(
+            '<html><head</head><body>' .
+            '<p style="margin: 2px !important; text-align: center;">some content</p>' .
+            '</body></html>'
+        );
+        $this->subject->setCss('p { margin: 1px !important; padding: 1px;}');
 
         $result = $this->subject->emogrify();
 
@@ -1828,11 +1753,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function addExcludedSelectorRemovesMatchingElementsFromEmogrification()
     {
-        $css = 'p { margin: 0; }';
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><p class="x"></p></body></html>');
-        $this->subject->setCss($css);
-        $this->subject->addExcludedSelector('p.x');
+        $this->subject->setHtml('<html><body><p class="x"></p></body></html>');
+        $this->subject->setCss('p { margin: 0; }');
 
+        $this->subject->addExcludedSelector('p.x');
         $result = $this->subject->emogrify();
 
         self::assertContains('<p class="x"></p>', $result);
@@ -1843,11 +1767,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function addExcludedSelectorExcludesMatchingElementEventWithWhitespaceAroundSelector()
     {
-        $css = 'p { margin: 0; }';
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><p class="x"></p></body></html>');
-        $this->subject->setCss($css);
-        $this->subject->addExcludedSelector(' p.x ');
+        $this->subject->setHtml('<html><body><p class="x"></p></body></html>');
+        $this->subject->setCss('p { margin: 0; }');
 
+        $this->subject->addExcludedSelector(' p.x ');
         $result = $this->subject->emogrify();
 
         self::assertContains('<p class="x"></p>', $result);
@@ -1858,11 +1781,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function addExcludedSelectorKeepsNonMatchingElementsInEmogrification()
     {
-        $css = 'p { margin: 0; }';
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><p></p></body></html>');
-        $this->subject->setCss($css);
-        $this->subject->addExcludedSelector('p.x');
+        $this->subject->setHtml('<html><body><p></p></body></html>');
+        $this->subject->setCss('p { margin: 0; }');
 
+        $this->subject->addExcludedSelector('p.x');
         $result = $this->subject->emogrify();
 
         self::assertContains('<p style="margin: 0;"></p>', $result);
@@ -1873,9 +1795,9 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function removeExcludedSelectorGetsMatchingElementsToBeEmogrifiedAgain()
     {
-        $css = 'p { margin: 0; }';
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><p class="x"></p></body></html>');
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html><body><p class="x"></p></body></html>');
+        $this->subject->setCss('p { margin: 0; }');
+
         $this->subject->addExcludedSelector('p.x');
         $this->subject->removeExcludedSelector('p.x');
 
@@ -1891,7 +1813,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         $emptyQuery = '@media all and (max-width: 500px) { }';
         $this->subject->setCss($emptyQuery);
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><p></p></body></html>');
+        $this->subject->setHtml('<html><body><p></p></body></html>');
 
         $result = $this->subject->emogrify();
 
@@ -1908,10 +1830,12 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             ".small {font-size:14px;}\r\n" .
             '}';
         $this->subject->setCss($css);
-        $this->subject->setHtml($this->html5DocumentType . '<html><body>' .
+        $this->subject->setHtml(
+            '<html><body>' .
             '<p class="medium">medium</p>' .
             '<p class="small">small</p>' .
-            '</body></html>');
+            '</body></html>'
+        );
 
         $result = $this->subject->emogrify();
 
@@ -1932,7 +1856,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             '}';
         $this->subject->setCss($css);
         $this->subject->setHtml(
-            $this->html5DocumentType . '<html><body>' .
+            '<html><body>' .
             '<p class="medium">medium</p>' .
             '<p class="small">small</p>' .
             '</body></html>'
@@ -1961,7 +1885,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             '}';
         $this->subject->setCss($css);
         $this->subject->setHtml(
-            $this->html5DocumentType . '<html><body>' .
+            '<html><body>' .
             '<p class="medium">medium</p>' .
             '<p class="small">small</p>' .
             '</body></html>'
@@ -1995,8 +1919,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function dataUrisAreConserved($dataUriMediaType)
     {
-        $html = $this->html5DocumentType . '<html></html>';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml('<html></html>');
         $styleRule = 'background-image: url(data:image/png' . $dataUriMediaType .
             ',iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAABUk' .
             'lEQVQ4y81UsY6CQBCdWXBjYWFMjEgAE0piY8c38B9+iX+ksaHCgs5YWEhIrJCQYGJBomiC7lzhVcfqEa+5KXfey3s783bRdd00TR' .
@@ -2094,10 +2017,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifierMapsSuitableCssToHtmlIfFeatureIsEnabled($body, $css, $tagName, $attributes)
     {
-        $this->subject->setHtml($this->html5DocumentType . '<html><body>' . $body . '</body></html>');
+        $this->subject->setHtml('<html><body>' . $body . '</body></html>');
         $this->subject->setCss($css);
-        $this->subject->enableCssToHtmlMapping();
 
+        $this->subject->enableCssToHtmlMapping();
         $html = $this->subject->emogrify();
 
         self::assertContains(
@@ -2149,10 +2072,10 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifierNotMapsUnsuitableCssToHtmlIfFeatureIsEnabled($body, $css, $attribute)
     {
-        $this->subject->setHtml($this->html5DocumentType . '<html><body>' . $body . '</body></html>');
+        $this->subject->setHtml('<html><body>' . $body . '</body></html>');
         $this->subject->setCss($css);
-        $this->subject->enableCssToHtmlMapping();
 
+        $this->subject->enableCssToHtmlMapping();
         $html = $this->subject->emogrify();
 
         self::assertNotContains(
@@ -2166,9 +2089,8 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifierNotMapsCssToHtmlIfFeatureIsNotEnabled()
     {
-        $css = 'img {float: right;}';
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><img></body></html>');
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html><body><img></body></html>');
+        $this->subject->setCss('img {float: right;}');
 
         $html = $this->subject->emogrify();
 
@@ -2183,11 +2105,11 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifierIgnoresPseudoClassCombinedWithPseudoElement()
     {
-        $css = 'div:last-child::after {float: right;}';
-        $this->subject->setHtml($this->html5DocumentType . '<html><body><div></div></body></html>');
-        $this->subject->setCss($css);
+        $this->subject->setHtml('<html><body><div></div></body></html>');
+        $this->subject->setCss('div:last-child::after {float: right;}');
 
         $html = $this->subject->emogrify();
+
         self::assertContains('<div></div>', $html);
     }
 }


### PR DESCRIPTION
- remove the document type from the HTML in the tests where the
  document type is not relevant
- inline $html and $css to make the tests more succinct

Fixes #137