### PR TITLE
[TASK] Drop support for HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ matrix:
     env: CODE_SNIFFER=yes
   - php: 7.1
     env: CODE_SNIFFER=yes
-  - php: hhvm
-    env: CODE_SNIFFER=yes
 
 install:
   - composer install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Removed
+- Drop support for HHVM
+  ([#386](https://github.com/jjriv/emogrifier/pull/386))
 
 
 ### Fixed

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -952,12 +952,6 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      */
     public function emogrifyForInvalidCssSelectorThrowsException()
     {
-        // HHVM ignores custom error handler settings for libxml.
-        // @see https://github.com/facebook/hhvm/issues/5790
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('HHVM ignore custom error handler');
-        }
-
         $this->subject->setHtml(
             '<html><style type="text/css">p{color:red;} <style data-x="1">html{cursor:text;}</style></html>'
         );


### PR DESCRIPTION
HHVM in PHP-7 mode breaks Composer.

Other big projects are dropping support for HHVM due to these issues, too.