### PR TITLE
[CLEANUP] Drop the condition for sniffing the code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,10 @@ env:
 matrix:
   include:
   - php: 5.4
-    env: CODE_SNIFFER=yes
   - php: 5.5
-    env: CODE_SNIFFER=yes
   - php: 5.6
-    env: CODE_SNIFFER=yes
   - php: 7.0
-    env: CODE_SNIFFER=yes
   - php: 7.1
-    env: CODE_SNIFFER=yes
 
 install:
   - composer install
@@ -34,6 +29,6 @@ script:
   # Run PHP lint on all PHP files.
   - find Classes/ Tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
   # Check the coding style.
-  - if [[ "CODE_SNIFFER" == "yes" ]]; then vendor/bin/phpcs --standard=Configuration/PhpCodeSniffer/Standards/Emogrifier/ Classes/ Tests/; fi
+  - vendor/bin/phpcs --standard=Configuration/PhpCodeSniffer/Standards/Emogrifier/ Classes/ Tests/
   # Run the unit tests.
   - vendor/bin/phpunit Tests/


### PR DESCRIPTION
As the code sniffer is executed for all PHP versions, we do not need a
version-dependent condition for it anymore.