### PR TITLE
Fix InvalidArgumentException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Debug mode. Throw debug exceptions only if debug is active.
+  ([#392](https://github.com/jjriv/emogrifier/pull/392))
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## x.y.z (unreleased)
 
 ### Added
-
+- Debug mode. Throw debug exceptions only if debug is active.
 
 ### Changed
 

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -1533,22 +1533,18 @@ class Emogrifier
      *
      * @throws \InvalidArgumentException
      */
-    public function handleXpathError($type, $message, $file, $line, array $context)
+     public function handleXpathError($type, $message, $file, $line, array $context)
     {
-        if ($type === E_WARNING && isset($context['cssRule']['selector'])) {
-            if ($this->debug) {
-                throw new \InvalidArgumentException(
-                    sprintf(
-                        '%s in selector >> %s << in %s on line %s',
-                        $message,
-                        $context['cssRule']['selector'],
-                        $file,
-                        $line
-                    )
-                );
-            } else {
-                return false;
-            }
+        if ($this->debug && $type === E_WARNING && isset($context['cssRule']['selector'])) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    '%s in selector >> %s << in %s on line %s',
+                    $message,
+                    $context['cssRule']['selector'],
+                    $file,
+                    $line
+                )
+            );
         }
 
         // the normal error handling continues when handler return false

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -367,8 +367,11 @@ class Emogrifier
         $cssRules = $this->parseCssRules($cssParts['css']);
         foreach ($cssRules as $cssRule) {
             // query the body for the xpath selector
-            $nodesMatchingCssSelectors = $xPath->query($this->translateCssToXpath($cssRule['selector']));
-            // ignore invalid selectors
+            try {
+                $nodesMatchingCssSelectors = $xPath->query($this->translateCssToXpath($cssRule['selector']));
+            } catch (\InvalidArgumentException $e) {
+                $nodesMatchingCssSelectors = false;
+            }            // ignore invalid selectors
             if ($nodesMatchingCssSelectors === false) {
                 continue;
             }

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -366,12 +366,13 @@ class Emogrifier
         $excludedNodes = $this->getNodesToExclude($xPath);
         $cssRules = $this->parseCssRules($cssParts['css']);
         foreach ($cssRules as $cssRule) {
-            // query the body for the xpath selector
             try {
+                // query the body for the xpath selector
                 $nodesMatchingCssSelectors = $xPath->query($this->translateCssToXpath($cssRule['selector']));
             } catch (\InvalidArgumentException $e) {
                 $nodesMatchingCssSelectors = false;
-            }            // ignore invalid selectors
+            }
+            // ignore invalid selectors
             if ($nodesMatchingCssSelectors === false) {
                 continue;
             }

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -226,6 +226,13 @@ class Emogrifier
     ];
 
     /**
+     * If true, allow debug Exception to be thrown.
+     *
+     * @var bool
+     */
+    private $debug = false;
+
+    /**
      * The constructor.
      *
      * @param string $html the HTML to emogrify, must be UTF-8-encoded
@@ -366,12 +373,8 @@ class Emogrifier
         $excludedNodes = $this->getNodesToExclude($xPath);
         $cssRules = $this->parseCssRules($cssParts['css']);
         foreach ($cssRules as $cssRule) {
-            try {
-                // query the body for the xpath selector
-                $nodesMatchingCssSelectors = $xPath->query($this->translateCssToXpath($cssRule['selector']));
-            } catch (\InvalidArgumentException $e) {
-                $nodesMatchingCssSelectors = false;
-            }
+            // query the body for the xpath selector
+            $nodesMatchingCssSelectors = $xPath->query($this->translateCssToXpath($cssRule['selector']));
             // ignore invalid selectors
             if ($nodesMatchingCssSelectors === false) {
                 continue;
@@ -1533,18 +1536,32 @@ class Emogrifier
     public function handleXpathError($type, $message, $file, $line, array $context)
     {
         if ($type === E_WARNING && isset($context['cssRule']['selector'])) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    '%s in selector >> %s << in %s on line %s',
-                    $message,
-                    $context['cssRule']['selector'],
-                    $file,
-                    $line
-                )
-            );
+            if ($this->debug) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        '%s in selector >> %s << in %s on line %s',
+                        $message,
+                        $context['cssRule']['selector'],
+                        $file,
+                        $line
+                    )
+                );
+            } else {
+                return false;
+            }
         }
 
         // the normal error handling continues when handler return false
         return false;
+    }
+
+    /**
+     * Set debug mode.
+     *
+     * @param bool $debug set to true to enable debug mode
+     */
+    public function setDebug($debug)
+    {
+        $this->debug = $debug;
     }
 }

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -1533,7 +1533,7 @@ class Emogrifier
      *
      * @throws \InvalidArgumentException
      */
-     public function handleXpathError($type, $message, $file, $line, array $context)
+    public function handleXpathError($type, $message, $file, $line, array $context)
     {
         if ($this->debug && $type === E_WARNING && isset($context['cssRule']['selector'])) {
             throw new \InvalidArgumentException(

--- a/Classes/Emogrifier.php
+++ b/Classes/Emogrifier.php
@@ -226,7 +226,7 @@ class Emogrifier
     ];
 
     /**
-     * If true, allow debug Exception to be thrown.
+     * Emogrifier will throw Exceptions when it encounters an error instead of silently ignoring them.
      *
      * @var bool
      */
@@ -1556,9 +1556,11 @@ class Emogrifier
     }
 
     /**
-     * Set debug mode.
+     * Sets the debug mode.
      *
      * @param bool $debug set to true to enable debug mode
+     *
+     * @return void
      */
     public function setDebug($debug)
     {

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -956,7 +956,24 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             '<html><style type="text/css">p{color:red;} <style data-x="1">html{cursor:text;}</style></html>'
         );
 
+        $this->subject->setDebug(true);
         $this->subject->emogrify();
+    }
+
+    /**
+     * @test
+     */
+    public function emogrifyIgnoreInvalidCssSelectors()
+    {
+        $html = '<html><style type="text/css">' .
+            'p{color:red;} <style data-x="1">html{cursor:text;} p{background-color:blue;}</style> ' .
+            '<body><p></p></body></html>';
+
+        $this->subject->setHtml($html);
+
+        $html = $this->subject->emogrify();
+        self::assertContains('color: red', $html);
+        self::assertContains('background-color: blue', $html);
     }
 
     /**

--- a/Tests/Unit/EmogrifierTest.php
+++ b/Tests/Unit/EmogrifierTest.php
@@ -950,7 +950,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
      *
      * @expectedException \InvalidArgumentException
      */
-    public function emogrifyForInvalidCssSelectorThrowsException()
+    public function emogrifyInDebugModeForInvalidCssSelectorThrowsException()
     {
         $this->subject->setHtml(
             '<html><style type="text/css">p{color:red;} <style data-x="1">html{cursor:text;}</style></html>'
@@ -963,7 +963,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function emogrifyIgnoreInvalidCssSelectors()
+    public function emogrifyNotInDebugModeIgnoresInvalidCssSelectors()
     {
         $html = '<html><style type="text/css">' .
             'p{color:red;} <style data-x="1">html{cursor:text;} p{background-color:blue;}</style> ' .


### PR DESCRIPTION
Fix InvalidArgumentException when xpath does not find the css selector (eg: css3 keyframes).

You can reproduce the InvalidArgumentException using the following css :
```css
@-moz-keyframes animate-stripes{
    0% {background-position: 0 0;} 100% {background-position: 60px 0;}
}
```