### PR TITLE
[BUGFIX] Use the correct Composer script names in the ci:static script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "ci:static": [
             "@ci:php:lint",
             "@ci:php:sniff",
-            "@ci:php:phpmd"
+            "@ci:php:md"
         ],
         "ci": [
             "@ci:static",


### PR DESCRIPTION
Now `composer ci:static` will run PHPMD as well.