### PR TITLE
[TASK] Drop the abandoned `rawr/cross-data-providers`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
       - dependency-name: "phpstan/*"
       - dependency-name: "phpunit/phpunit"
         versions: [ ">= 10.0.0" ]
-      - dependency-name: "rawr/cross-data-providers"
       - dependency-name: "rector/rector"
     versioning-strategy: "increase"
     commit-message:

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,6 @@
         "phpstan/phpstan-phpunit": "1.4.2 || 2.0.6",
         "phpstan/phpstan-strict-rules": "1.6.2 || 2.0.4",
         "phpunit/phpunit": "9.6.23",
-        "rawr/cross-data-providers": "2.4.0",
         "rawr/phpunit-data-provider": "3.3.1",
         "rector/rector": "1.2.10 || 2.0.16",
         "rector/type-perfect": "1.0.0 || 2.1.0"


### PR DESCRIPTION
This package has been abandoned in favor of its successor `rawr/phpunit-data-provider`.

Closes #1317