### PR TITLE
[TASK] Improve the Composer script naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: composer config --global --list
 
       - name: PHP Lint
-        # Note: Unlike the "ci:php:lint" Composer script, we do not use the
+        # Note: Unlike the "check:php:lint" Composer script, we do not use the
         # "parallel-lint" tool here. This allows us to lint the files without
         # depending on any Composer packages.
         run: find config src tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
@@ -137,7 +137,7 @@ jobs:
         run: phive --no-progress install --trust-gpg-keys 0FDE18AE1D09E19F60F6B1CBC00543248C87FB13,BBAB5DF0A0D6672989CF1869E82B2FB314E9906E
 
       - name: Run Command
-        run: composer ci:${{ matrix.command }}
+        run: composer check:${{ matrix.command }}
 
   unit-tests:
     name: Unit tests
@@ -200,4 +200,4 @@ jobs:
           composer show;
 
       - name: Run Tests
-        run: composer ci:tests:unit
+        run: composer check:tests:unit

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -60,7 +60,7 @@ jobs:
           composer show;
 
       - name: Run Tests
-        run: composer ci:tests:coverage
+        run: composer check:tests:coverage
 
       - name: Show generated coverage files
         run: ls -lah

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ code coverage of the fixed bugs and the new features.
 To run the existing PHPUnit tests, run this command:
 
 ```bash
-composer ci:tests:unit
+composer check:tests:unit
 ```
 
 ## Coding Style
@@ -94,7 +94,7 @@ We will only merge pull requests that follow the project's coding style.
 Please check your code with the provided static code analysis tools:
 
 ```bash
-composer ci:static
+composer check:static
 ```
 
 Please make your code clean, well-readable and easy to understand.

--- a/composer.json
+++ b/composer.json
@@ -82,33 +82,33 @@
         }
     },
     "scripts": {
-        "ci": [
-            "@ci:static",
-            "@ci:dynamic"
+        "check": [
+            "@check:static",
+            "@check:dynamic"
         ],
-        "ci:composer:normalize": "\"./.phive/composer-normalize\" --dry-run",
-        "ci:dynamic": [
-            "@ci:tests"
+        "check:composer:normalize": "\"./.phive/composer-normalize\" --dry-run",
+        "check:dynamic": [
+            "@check:tests"
         ],
-        "ci:php:fixer": "\"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots config/ src/ tests/",
-        "ci:php:lint": "parallel-lint config src tests",
-        "ci:php:md": "phpmd src text config/phpmd.xml",
-        "ci:php:rector": "rector --no-progress-bar --dry-run --config=config/rector.php",
-        "ci:php:stan": "phpstan --no-progress --configuration=config/phpstan.neon",
-        "ci:static": [
-            "@ci:composer:normalize",
-            "@ci:php:lint",
-            "@ci:php:fixer",
-            "@ci:php:md",
-            "@ci:php:rector",
-            "@ci:php:stan"
+        "check:php:fixer": "\"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots config/ src/ tests/",
+        "check:php:lint": "parallel-lint config src tests",
+        "check:php:md": "phpmd src text config/phpmd.xml",
+        "check:php:rector": "rector --no-progress-bar --dry-run --config=config/rector.php",
+        "check:php:stan": "phpstan --no-progress --configuration=config/phpstan.neon",
+        "check:static": [
+            "@check:composer:normalize",
+            "@check:php:lint",
+            "@check:php:fixer",
+            "@check:php:md",
+            "@check:php:rector",
+            "@check:php:stan"
         ],
-        "ci:tests": [
-            "@ci:tests:unit"
+        "check:tests": [
+            "@check:tests:unit"
         ],
-        "ci:tests:coverage": "phpunit --do-not-cache-result --coverage-clover=coverage.xml",
-        "ci:tests:sof": "phpunit --stop-on-failure --do-not-cache-result",
-        "ci:tests:unit": "phpunit --do-not-cache-result",
+        "check:tests:coverage": "phpunit --do-not-cache-result --coverage-clover=coverage.xml",
+        "check:tests:sof": "phpunit --stop-on-failure --do-not-cache-result",
+        "check:tests:unit": "phpunit --do-not-cache-result",
         "fix": [
             "@fix:composer:normalize",
             "@fix:php:rector",
@@ -121,19 +121,19 @@
         "phpstan:baseline": "phpstan --configuration=config/phpstan.neon --generate-baseline=config/phpstan-baseline.neon --allow-empty-baseline"
     },
     "scripts-descriptions": {
-        "ci": "Runs all dynamic and static code checks.",
-        "ci:composer:normalize": "Checks the formatting and structure of the composer.json.",
-        "ci:dynamic": "Runs all dynamic tests (i.e., currently, the unit tests).",
-        "ci:php:fixer": "Checks the code style with PHP CS Fixer.",
-        "ci:php:lint": "Lints the PHP files for syntax errors.",
-        "ci:php:md": "Checks the code complexity with PHPMD.",
-        "ci:php:rector": "Checks the code for possible code updates and refactoring.",
-        "ci:php:stan": "Checks the PHP types using PHPStan.",
-        "ci:static": "Runs all static code analysis checks for the code and the composer.json.",
-        "ci:tests": "Runs all dynamic tests (i.e., currently, the unit tests).",
-        "ci:tests:coverage": "Runs the unit tests with code coverage.",
-        "ci:tests:sof": "Runs the unit tests and stops at the first failure.",
-        "ci:tests:unit": "Runs all unit tests.",
+        "check": "Runs all dynamic and static code checks.",
+        "check:composer:normalize": "Checks the formatting and structure of the composer.json.",
+        "check:dynamic": "Runs all dynamic tests (i.e., currently, the unit tests).",
+        "check:php:fixer": "Checks the code style with PHP CS Fixer.",
+        "check:php:lint": "Lints the PHP files for syntax errors.",
+        "check:php:md": "Checks the code complexity with PHPMD.",
+        "check:php:rector": "Checks the code for possible code updates and refactoring.",
+        "check:php:stan": "Checks the PHP types using PHPStan.",
+        "check:static": "Runs all static code analysis checks for the code and the composer.json.",
+        "check:tests": "Runs all dynamic tests (i.e., currently, the unit tests).",
+        "check:tests:coverage": "Runs the unit tests with code coverage.",
+        "check:tests:sof": "Runs the unit tests and stops at the first failure.",
+        "check:tests:unit": "Runs all unit tests.",
         "fix": "Runs all fixers",
         "fix:composer:normalize": "Reformats and sorts the composer.json file.",
         "fix:php:fixer": "Reformats the code with php-cs-fixer.",


### PR DESCRIPTION
The scripts for checking things are not CI-specific. So rename their shared prefix from `ci:` to `check:`.