### PR TITLE
[TASK] Improve `StyleRule::getDeclarationAsText` naming

### DIFF
--- a/src/Css/StyleRule.php
+++ b/src/Css/StyleRule.php
@@ -53,7 +53,7 @@ final class StyleRule
     /**
      * @return string the CSS declarations, separated and followed by a semicolon, e.g., `color: red; height: 4px;`
      */
-    public function getDeclarationAsText(): string
+    public function getDeclarationsAsText(): string
     {
         $rules = $this->declarationBlock->getRules();
         $renderedRules = [];

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -620,7 +620,7 @@ final class CssInliner extends AbstractHtmlProcessor
             }
 
             $mediaQuery = $cssRule->getContainingAtRule();
-            $declarationsBlock = $cssRule->getDeclarationAsText();
+            $declarationsBlock = $cssRule->getDeclarationsAsText();
             $selectors = $cssRule->getSelectors();
 
             // Maybe exclude CSS selectors

--- a/tests/Unit/Css/CssDocumentTest.php
+++ b/tests/Unit/Css/CssDocumentTest.php
@@ -129,7 +129,7 @@ final class CssDocumentTest extends TestCase
         $result = $subject->getStyleRulesData([]);
 
         self::assertCount(1, $result);
-        self::assertEquivalentCss($declarations, $result[0]->getDeclarationAsText());
+        self::assertEquivalentCss($declarations, $result[0]->getDeclarationsAsText());
     }
 
     /**

--- a/tests/Unit/Css/StyleRuleTest.php
+++ b/tests/Unit/Css/StyleRuleTest.php
@@ -89,7 +89,7 @@ final class StyleRuleTest extends TestCase
      *
      * @dataProvider provideDeclarations
      */
-    public function getDeclarationAsTextReturnsConcatenatedDeclarationsFromRules(
+    public function getDeclarationsAsTextReturnsConcatenatedDeclarationsFromRules(
         array $declarations,
         string $expected
     ): void {
@@ -103,7 +103,7 @@ final class StyleRuleTest extends TestCase
         }
         $styleRule = new StyleRule($declarationBlock, '');
 
-        self::assertSame($expected, $styleRule->getDeclarationAsText());
+        self::assertSame($expected, $styleRule->getDeclarationsAsText());
     }
 
     /**


### PR DESCRIPTION
This method can return multiple declarations as text. So we should name it accordingly.

As the class in which the method resides is `@internal`, we don't need a changelog entry for this change.