### PR TITLE
Enhance regex to match custom properties

### DIFF
--- a/src/Utilities/DeclarationBlockParser.php
+++ b/src/Utilities/DeclarationBlockParser.php
@@ -82,7 +82,7 @@ final class DeclarationBlockParser
         $properties = [];
         foreach ($declarations as $declaration) {
             $matches = [];
-            if (preg_match('/^(-?[a-zA-Z_][a-zA-Z_0-9\-]++|--[a-zA-Z_0-9\-]++)\\s*+:\\s*(.++)$/s', \trim($declaration), $matches) === 0) {
+            if (preg_match('/^(-?+[a-zA-Z_][a-zA-Z_0-9\\-]++|--[a-zA-Z_0-9\\-]++)\\s*+:\\s*(.++)$/s', \trim($declaration), $matches) === 0) {
                 continue;
             }
 

--- a/tests/Unit/Utilities/DeclarationBlockParserTest.php
+++ b/tests/Unit/Utilities/DeclarationBlockParserTest.php
@@ -156,6 +156,38 @@ final class DeclarationBlockParserTest extends TestCase
                 'string' => '--Base_size-4u: normal;',
                 'array' => ['--Base_size-4u' => 'normal'],
             ],
+            'specification test underscore allowed' => [
+                'string' => '_allowed: normal;',
+                'array' => ['_allowed' => 'normal'],
+            ],
+            'specification test hyphen underscore allowed' => [
+                'string' => '-_allowed: normal;',
+                'array' => ['-_allowed' => 'normal'],
+            ],
+            'specification test double hyphen underscore allowed' => [
+                'string' => '--_allowed: normal;',
+                'array' => ['--_allowed' => 'normal'],
+            ],
+            'specification test double underscore allowed' => [
+                'string' => '__allowed: normal;',
+                'array' => ['__allowed' => 'normal'],
+            ],
+            'specification test number not allowed' => [
+                'string' => '2not-allowed: unset;',
+                'array' => [],
+            ],
+            'specification test hyphen number not allowed' => [
+                'string' => '-2not-allowed: unset;',
+                'array' => [],
+            ],
+            'specification test double hyphen number allowed' => [
+                'string' => '--2allowed: normal;',
+                'array' => ['--2allowed' => 'normal'],
+            ],
+            'specification test backslash not allowed' => [
+                'string' => 'not\\allowed: unset;',
+                'array' => [],
+            ],
             'declaration using custom property' => [
                 'string' => 'color: var(--text-color);',
                 'array' => ['color' => 'var(--text-color)'],


### PR DESCRIPTION
CSS custom property names must start with "--" and contain extra characters which may be any letter, number, underscore or hyphen.

This fixes eg. custom property name "--base-size-16: 1rem;".

There are other options for the regex. Eg. `'/^([A-Za-z\\-][A-Za-z0-9_\\-]*)\\s*:\\s*(.+)$/s'` should work (will be less precise) and https://github.com/MyIntervals/emogrifier/blob/cd4d1724c337dc19eb768bc026c6a0be89b4c079/src/CssInliner.php#L452 has a different take.