### PR TITLE
[BUGFIX] Allow single character CSS properties

### DIFF
--- a/src/Utilities/DeclarationBlockParser.php
+++ b/src/Utilities/DeclarationBlockParser.php
@@ -83,7 +83,7 @@ final class DeclarationBlockParser
         foreach ($declarations as $declaration) {
             $matches = [];
             if (preg_match(
-                '/^(-?+[a-zA-Z_][a-zA-Z_0-9\\-]++|--[a-zA-Z_0-9\\-]++)\\s*+:\\s*(.++)$/s',
+                '/^(-?+[a-zA-Z_][a-zA-Z_0-9\\-]*+|--[a-zA-Z_0-9\\-]++)\\s*+:\\s*+(.++)$/s',
                 \trim($declaration),
                 $matches
             ) === 0) {

--- a/tests/Unit/Utilities/DeclarationBlockParserTest.php
+++ b/tests/Unit/Utilities/DeclarationBlockParserTest.php
@@ -156,6 +156,14 @@ final class DeclarationBlockParserTest extends TestCase
                 'string' => '--Base_size-4u: normal;',
                 'array' => ['--Base_size-4u' => 'normal'],
             ],
+            'specification test single character allowed' => [
+                'string' => 'x: 0;',
+                'array' => ['x' => '0'],
+            ],
+            'specification test hyphen single character allowed' => [
+                'string' => '-o: normal;',
+                'array' => ['-o' => 'normal'],
+            ],
             'specification test underscore allowed' => [
                 'string' => '_allowed: normal;',
                 'array' => ['_allowed' => 'normal'],


### PR DESCRIPTION
There are no real-world examples, but the specification does allow for this:

https://drafts.csswg.org/css-syntax-3/#ident-token-diagram

This potential issue was introduced by a tiny mistake in #1500, which already has a changelog entry.  As there has not been a release since, no changelog entry is needed for this change.

Also add another possessive quantifier to the regex to improve performance.