### PR TITLE
[TASK] Use safe preg functions in `CssInliner`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Please also have a look at our
 
 - Allow numbers and underscores in CSS property names (#1500)
 - Use safe version of some PHP functions
-  (#1457, #1492, #1495, #1496, #1499, #1503, #1513)
+  (#1457, #1492, #1495, #1496, #1499, #1503, #1513, #1515)
 
 ## 8.1.0: Add support for PHP 8.5
 

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -11,6 +11,7 @@ use Pelago\Emogrifier\Utilities\DeclarationBlockParser;
 use Symfony\Component\CssSelector\CssSelectorConverter;
 use Symfony\Component\CssSelector\Exception\ParseException;
 
+use function Safe\preg_match;
 use function Safe\preg_replace;
 use function Safe\preg_replace_callback;
 use function Safe\preg_split;


### PR DESCRIPTION
This fixes a missing import. (Once we've added the `thecodingmachine/phpstan-safe-rule` package, PHPStan is going to warn us about these.)

Part of #919