### PR TITLE
[TASK] Increase test severity for very large `meta` content in `head`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please also have a look at our
 
 ### Fixed
 
+- Support very large content in `meta` element in `head` (#1519)
 - Support very large HTML files without a `Content-Type` (#1518)
 - Allow numbers and underscores in CSS property names (#1500)
 - Use safe version of some PHP functions

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -1130,8 +1130,7 @@ final class AbstractHtmlProcessorTest extends TestCase
                 '</body></html>',
             ],
             'HEAD with very large content' => [
-                // todo: failing with 1e7
-                '<head><meta name="test" content="' . \str_repeat('f', (int) 1e3) . '"/></head>',
+                '<head><meta name="test" content="' . \str_repeat('f', (int) 1e7) . '"/></head>',
                 '',
             ],
         ];


### PR DESCRIPTION
The noted issue seems fixed by #1519.
Changelog is updated accordingly.