### PR TITLE
[CLEANUP] Drop PHPDoc type annotations for constants

### DIFF
--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -21,14 +21,7 @@ use function Safe\preg_split;
  */
 final class CssInliner extends AbstractHtmlProcessor
 {
-    /**
-     * @var int<0, 1>
-     */
     private const CACHE_KEY_SELECTOR = 0;
-
-    /**
-     * @var int<0, 1>
-     */
     private const CACHE_KEY_COMBINED_STYLES = 1;
 
     /**
@@ -36,8 +29,6 @@ final class CssInliner extends AbstractHtmlProcessor
      * for which the applicable elements can be determined (by converting the selector to an XPath expression).
      * (Contains alternation without a group and is intended to be placed within a capturing, non-capturing or lookahead
      * group, as appropriate for the usage context.)
-     *
-     * @var non-empty-string
      */
     private const PSEUDO_CLASS_MATCHER
         = 'empty|(?:first|last|nth(?:-last)?+|only)-(?:child|of-type)|not\\([[:ascii:]]*\\)|root';
@@ -45,22 +36,16 @@ final class CssInliner extends AbstractHtmlProcessor
     /**
      * This regular expression component matches an `...of-type` pseudo class name, without the preceding ":".  These
      * pseudo-classes can currently online be inlined if they have an associated type in the selector expression.
-     *
-     * @var non-empty-string
      */
     private const OF_TYPE_PSEUDO_CLASS_MATCHER = '(?:first|last|nth(?:-last)?+|only)-of-type';
 
     /**
      * regular expression component to match a selector combinator
-     *
-     * @var non-empty-string
      */
     private const COMBINATOR_MATCHER = '(?:\\s++|\\s*+[>+~]\\s*+)(?=[[:alpha:]_\\-.#*:\\[])';
 
     /**
      * options array key for `querySelectorAll`
-     *
-     * @var non-empty-string
      */
     private const QSA_ALWAYS_THROW_PARSE_EXCEPTION = 'alwaysThrowParseException';
 

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -14,20 +14,13 @@ use function Safe\preg_replace;
  */
 abstract class AbstractHtmlProcessor
 {
-    /**
-     * @var non-empty-string
-     */
     protected const DEFAULT_DOCUMENT_TYPE = '<!DOCTYPE html>';
-
-    /**
-     * @var non-empty-string
-     */
     protected const CONTENT_TYPE_META_TAG = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">';
 
     /**
-     * @var non-empty-string Regular expression part to match tag names that PHP's DOMDocument implementation is not
-     *      aware are self-closing. These are mostly HTML5 elements, but for completeness `<command>` (obsolete) and
-     *      `<keygen>` (deprecated) are also included.
+     * Regular expression part to match tag names that PHP's DOMDocument implementation is not
+     * aware are self-closing. These are mostly HTML5 elements, but for completeness `<command>` (obsolete) and
+     * `<keygen>` (deprecated) are also included.
      *
      * @see https://bugs.php.net/bug.php?id=73175
      */
@@ -36,23 +29,17 @@ abstract class AbstractHtmlProcessor
     /**
      * Regular expression part to match tag names that may appear before the start of the `<body>` element.  A start tag
      * for any other element would implicitly start the `<body>` element due to tag omission rules.
-     *
-     * @var non-empty-string
      */
     protected const TAGNAME_ALLOWED_BEFORE_BODY_MATCHER
         = '(?:html|head|base|command|link|meta|noscript|script|style|template|title)';
 
     /**
      * regular expression pattern to match an HTML comment, including delimiters and modifiers
-     *
-     * @var non-empty-string
      */
     protected const HTML_COMMENT_PATTERN = '/<!--[^-]*+(?:-(?!->)[^-]*+)*+(?:-->|$)/';
 
     /**
      * regular expression pattern to match an HTML `<template>` element, including delimiters and modifiers
-     *
-     * @var non-empty-string
      */
     protected const HTML_TEMPLATE_ELEMENT_PATTERN
         = '%<template[\\s>][^<]*+(?:<(?!/template>)[^<]*+)*+(?:</template>|$)%i';

--- a/src/HtmlProcessor/HtmlPruner.php
+++ b/src/HtmlProcessor/HtmlPruner.php
@@ -20,8 +20,6 @@ final class HtmlPruner extends AbstractHtmlProcessor
      * supports XPath 1.0, lower-case() isn't available to us. We've thus far only set attributes to lowercase,
      * not attribute values. Consequently, we need to translate() the letters that would be in 'NONE' ("NOE")
      * to lowercase.
-     *
-     * @var non-empty-string
      */
     private const DISPLAY_NONE_MATCHER
         = '//*[@style and contains(translate(translate(@style," ",""),"NOE","noe"),"display:none")'

--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -21,8 +21,6 @@ abstract class CssConstraint extends Constraint
     /**
      * This regular expression pattern will match various parts of a string of CSS, and uses capturing groups to clarify
      * what, actually, has been matched.
-     *
-     * @var non-empty-string
      */
     private const CSS_REGULAR_EXPRESSION_PATTERN = '/
         (?<![\\s;}])                        # - `}` as end of declarations rule block, captured in group 1, with
@@ -102,22 +100,14 @@ abstract class CssConstraint extends Constraint
         )++                                 #
     /x';
 
-    /**
-     * @var non-empty-string
-     */
     private const URL_REPLACEMENT_MATCHER = '(?:([\'"]?+)$8$10\\g{-1})';
 
-    /**
-     * @var non-empty-string
-     */
     private const AT_IMPORT_URL_REPLACEMENT_MATCHER = '@(?i:import)\\s++(?:' . self::URL_REPLACEMENT_MATCHER
         . '|url\\(\\s*+' . self::URL_REPLACEMENT_MATCHER . '\\s*+\\))';
 
     /**
      * Regular expression replacements for parts of the CSS matched by {@see CSS_REGULAR_EXPRESSION_PATTERN}, indexed by
      * capturing group upon which capturing a non-empty string means the corresponding replacement should be selected.
-     *
-     * @var array<int<1, 16>, non-empty-string>
      */
     private const CSS_REGULAR_EXPRESSION_REPLACEMENTS = [
         1 => '(?:\\s*+;)?+\\s*+$1\\s*+',
@@ -140,8 +130,6 @@ abstract class CssConstraint extends Constraint
      * `\s++`.
      * It matches the end of the string, and optionally preceding whitespace or a semicolon surrounded by optional
      * whitespace, provided that what precedes is not a semicolon or whitespace.
-     *
-     * @var non-empty-string
      */
     private const OPTIONAL_TRAILING_SEMICOLON_MATCHER_PATTERN
         = '/(?<!;)(?<!\\\\s[\\+\\*]\\+)(?:\\\\s\\*\\+;\\\\s\\*\\+|\\\\s\\+\\+)?+$/';

--- a/tests/Unit/Css/CssDocumentTest.php
+++ b/tests/Unit/Css/CssDocumentTest.php
@@ -19,9 +19,6 @@ final class CssDocumentTest extends TestCase
 {
     use AssertCss;
 
-    /**
-     * @var non-empty-string
-     */
     private const VALID_AT_FONT_FACE_RULE = '@font-face {' . "\n"
         . '  font-family: "Foo Sans";' . "\n"
         . '  src: url("/foo-sans.woff2") format("woff2");' . "\n}";

--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -25,7 +25,7 @@ final class CssInlinerTest extends TestCase
     use AssertCss;
 
     /**
-     * @var string Common HTML markup with a variety of elements and attributes for testing with
+     * Common HTML markup with a variety of elements and attributes for testing with
      */
     private const COMMON_TEST_HTML = '
         <html>
@@ -54,8 +54,6 @@ final class CssInlinerTest extends TestCase
     ';
 
     /**
-     * @var array<string, string>
-     *
      * selection of at-rules which have no special handling by `CssInliner` but should be passed through and placed in a
      * `<style>` element unmodified, for testing that and testing around
      */

--- a/tests/Unit/HtmlProcessor/CssVariableEvaluatorTest.php
+++ b/tests/Unit/HtmlProcessor/CssVariableEvaluatorTest.php
@@ -13,9 +13,6 @@ use PHPUnit\Framework\TestCase;
  */
 final class CssVariableEvaluatorTest extends TestCase
 {
-    /**
-     * @var non-empty-string
-     */
     private const COMMON_TEST_HTML = '
         <html>
             <head>


### PR DESCRIPTION
It has turned out that PHPStan does not need them.

Fixes #1521