### PR TITLE
[CLEANUP] Drop redundant type annotations from the tests

### DIFF
--- a/tests/Unit/CssInlinerTest.php
+++ b/tests/Unit/CssInlinerTest.php
@@ -149,8 +149,6 @@ final class CssInlinerTest extends TestCase
      * Builds a subject with the given HTML and debug mode enabled.
      *
      * @param non-empty-string $html
-     *
-     * @return CssInliner
      */
     private function buildDebugSubject(string $html): CssInliner
     {
@@ -1716,9 +1714,6 @@ final class CssInlinerTest extends TestCase
     /**
      * @test
      *
-     * @param string $unneededCss
-     * @param string $markerNotExpectedInHtml
-     *
      * @dataProvider unneededCssThingsDataProvider
      */
     public function inlineCssFiltersUnneededCssThings(string $unneededCss, string $markerNotExpectedInHtml): void
@@ -1732,8 +1727,6 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $unneededCss
      *
      * @dataProvider unneededCssThingsDataProvider
      */
@@ -1864,8 +1857,6 @@ final class CssInlinerTest extends TestCase
     /**
      * @test
      *
-     * @param string $rule1
-     * @param string $rule2
      * @param string $cssBefore CSS to insert before the first rule
      * @param string $cssBetween CSS to insert between the rules
      * @param string $cssAfter CSS to insert after the second rule
@@ -2035,8 +2026,6 @@ final class CssInlinerTest extends TestCase
     /**
      * @test
      *
-     * @param string $css
-     *
      * @dataProvider validMediaPreserveDataProvider
      */
     public function inlineCssWithValidMediaQueryContainsInnerCss(string $css): void
@@ -2050,8 +2039,6 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $css
      *
      * @dataProvider validMediaPreserveDataProvider
      */
@@ -2071,8 +2058,6 @@ final class CssInlinerTest extends TestCase
     /**
      * @test
      *
-     * @param string $css
-     *
      * @dataProvider validMediaPreserveDataProvider
      */
     public function inlineCssForHtmlWithValidMediaQueryContainsInnerCss(string $css): void
@@ -2086,8 +2071,6 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $css
      *
      * @dataProvider validMediaPreserveDataProvider
      */
@@ -2137,8 +2120,6 @@ final class CssInlinerTest extends TestCase
     /**
      * @test
      *
-     * @param string $css
-     *
      * @dataProvider invalidMediaPreserveDataProvider
      */
     public function inlineCssWithInvalidMediaQueryNotContainsInlineCss(string $css): void
@@ -2168,8 +2149,6 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $css
      *
      * @dataProvider invalidMediaPreserveDataProvider
      */
@@ -2586,9 +2565,6 @@ final class CssInlinerTest extends TestCase
     /**
      * @test
      *
-     * @param string $emptyRuleMediaType
-     * @param string $mediaType
-     *
      * @dataProvider mediaTypesDataProvider
      */
     public function inlineCssAppliesCssBetweenEmptyMediaRuleAndMediaRule(
@@ -2607,9 +2583,6 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $emptyRuleMediaType
-     * @param string $mediaType
      *
      * @dataProvider mediaTypesDataProvider
      */
@@ -2802,8 +2775,6 @@ final class CssInlinerTest extends TestCase
      * Sets HTML of subject to boilerplate HTML with a single `<p>` in `<body>` and empty `<head>`
      *
      * @param string $style Optional value for the style attribute of the `<p>` element
-     *
-     * @return CssInliner
      */
     private function buildSubjectWithBoilerplateHtml(string $style = ''): CssInliner
     {
@@ -2833,8 +2804,6 @@ final class CssInlinerTest extends TestCase
     /**
      * @test
      *
-     * @param string $importantMarker
-     *
      * @dataProvider provideImportantDeclarationMarker
      */
     public function inlineCssRemovesImportantFromStyleAttribute(string $importantMarker): void
@@ -2848,8 +2817,6 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $importantMarker
      *
      * @dataProvider provideImportantDeclarationMarker
      */
@@ -2865,8 +2832,6 @@ final class CssInlinerTest extends TestCase
     /**
      * @test
      *
-     * @param string $importantMarker
-     *
      * @dataProvider provideImportantDeclarationMarker
      */
     public function importantInExternalCssOverwritesInlineCss(string $importantMarker): void
@@ -2881,8 +2846,6 @@ final class CssInlinerTest extends TestCase
     /**
      * @test
      *
-     * @param string $importantMarker
-     *
      * @dataProvider provideImportantDeclarationMarker
      */
     public function importantInExternalCssNotOverwritesImportantInInlineCss(string $importantMarker): void
@@ -2896,8 +2859,6 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $importantMarker
      *
      * @dataProvider provideImportantDeclarationMarker
      */
@@ -3356,8 +3317,6 @@ final class CssInlinerTest extends TestCase
     /**
      * @test
      *
-     * @param string $dataUriMediaType
-     *
      * @dataProvider dataUriMediaTypeDataProvider
      */
     public function dataUrisAreConserved(string $dataUriMediaType): void
@@ -3458,9 +3417,6 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $originalStyleAttributeContent
-     * @param string $expectedStyleAttributeContent
      *
      * @dataProvider cssForImportantRuleRemovalDataProvider
      */
@@ -3575,9 +3531,7 @@ final class CssInlinerTest extends TestCase
     /**
      * @test
      *
-     * @param string $cssBefore
      * @param non-empty-string $cssImports
-     * @param string $cssAfter
      *
      * @dataProvider provideValidImportRules
      */
@@ -3621,8 +3575,6 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $css
      *
      * @dataProvider provideInvalidImportRules
      */
@@ -3728,8 +3680,6 @@ final class CssInlinerTest extends TestCase
     /**
      * @test
      *
-     * @param string $atRule
-     *
      * @dataProvider provideValidAtRules
      */
     public function inlineCssMatchesRuleAfterAtRule(string $atRule): void
@@ -3743,8 +3693,6 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $atRule
      *
      * @dataProvider provideValidAtRules
      */
@@ -3775,8 +3723,6 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $css
      *
      * @dataProvider provideInvalidFontFaceRules
      */
@@ -3851,8 +3797,6 @@ final class CssInlinerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $selector
      *
      * @dataProvider nonMatchingOrInlinableSelectorDataProvider
      */

--- a/tests/Unit/HtmlProcessor/HtmlPrunerTest.php
+++ b/tests/Unit/HtmlProcessor/HtmlPrunerTest.php
@@ -77,8 +77,6 @@ final class HtmlPrunerTest extends TestCase
     /**
      * @test
      *
-     * @param string $displayNone
-     *
      * @dataProvider displayNoneDataProvider
      */
     public function removeElementsWithDisplayNoneRemovesElementsWithDisplayNone(string $displayNone): void
@@ -104,8 +102,6 @@ final class HtmlPrunerTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $classAttributeValue
      *
      * @dataProvider provideEmogrifierKeepClassAttribute
      */
@@ -210,7 +206,6 @@ final class HtmlPrunerTest extends TestCase
     /**
      * @test
      *
-     * @param string $html
      * @param array<int, string> $classesToKeep
      *
      * @dataProvider provideHtmlAndNonMatchedClasses
@@ -290,7 +285,6 @@ final class HtmlPrunerTest extends TestCase
     /**
      * @test
      *
-     * @param string $html
      * @param array<int, string> $classesToKeep
      * @param array<int, string> $classesExpectedToBeRemoved
      *
@@ -359,7 +353,6 @@ final class HtmlPrunerTest extends TestCase
     /**
      * @test
      *
-     * @param string $html
      * @param array<int, string> $classesToKeep
      *
      * @dataProvider provideHtmlAndSomeMatchedClasses
@@ -383,7 +376,6 @@ final class HtmlPrunerTest extends TestCase
     /**
      * @test
      *
-     * @param string $html
      * @param array<int, string> $classesToKeep
      *
      * @dataProvider provideHtmlWithExtraWhitespaceAndSomeMatchedClasses
@@ -491,8 +483,6 @@ final class HtmlPrunerTest extends TestCase
     /**
      * @test
      *
-     * @param string $html
-     * @param string $css
      * @param array<int, string> $classesExpectedToBeRemoved
      *
      * @dataProvider provideClassesNotInUninlinableRules
@@ -552,8 +542,6 @@ final class HtmlPrunerTest extends TestCase
     /**
      * @test
      *
-     * @param string $html
-     * @param string $css
      * @param array<int, string> $classesToBeKept
      *
      * @dataProvider provideClassesInUninlinableRules
@@ -575,7 +563,6 @@ final class HtmlPrunerTest extends TestCase
      * Asserts that none of the `$needles` can be found within the string `$haystack`.
      *
      * @param array<int, string> $needles
-     * @param string $haystack
      *
      * @throws ExpectationFailedException
      */
@@ -590,7 +577,6 @@ final class HtmlPrunerTest extends TestCase
      * Asserts that all of the `$needles` can be found within the string `$haystack`.
      *
      * @param array<int, string> $needles
-     * @param string $haystack
      *
      * @throws ExpectationFailedException
      */
@@ -603,10 +589,6 @@ final class HtmlPrunerTest extends TestCase
 
     /**
      * Asserts that the number of occurrences of `$needle` within the string `$haystack` is as expected.
-     *
-     * @param int $expectedCount
-     * @param string $haystack
-     * @param string $needle
      *
      * @throws ExpectationFailedException
      */
@@ -621,8 +603,6 @@ final class HtmlPrunerTest extends TestCase
 
     /**
      * Asserts that a string does not contain consecutive whitespace characters, or begin or end with whitespace.
-     *
-     * @param string $string
      *
      * @throws ExpectationFailedException
      */

--- a/tests/Unit/Support/Constraint/CssConstraintTest.php
+++ b/tests/Unit/Support/Constraint/CssConstraintTest.php
@@ -65,9 +65,6 @@ final class CssConstraintTest extends TestCase
     /**
      * @test
      *
-     * @param string $contentToInsertAround
-     * @param string $otherContent
-     *
      * @dataProvider contentWithOptionalWhitespaceDataProvider
      */
     public function getCssRegularExpressionMatcherInsertsOptionalWhitespace(
@@ -112,8 +109,6 @@ final class CssConstraintTest extends TestCase
     /**
      * @test
      *
-     * @param string $css
-     *
      * @dataProvider styleTagDataProvider
      */
     public function getCssRegularExpressionMatcherInsertsOptionalWhitespaceAfterStyleTag(string $css): void
@@ -139,8 +134,6 @@ final class CssConstraintTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $css
      *
      * @dataProvider provideWhitespaceBetweenWords
      */

--- a/tests/Unit/Support/Constraint/Fixtures/TestingCssConstraint.php
+++ b/tests/Unit/Support/Constraint/Fixtures/TestingCssConstraint.php
@@ -13,10 +13,6 @@ abstract class TestingCssConstraint extends CssConstraint
 {
     /**
      * Chains on to {@see getCssRegularExpressionMatcher} for testing the protected method.
-     *
-     * @param string $css
-     *
-     * @return string
      */
     public static function getCssRegularExpressionMatcherForTesting(string $css): string
     {

--- a/tests/Unit/Support/Constraint/IsEquivalentCssTest.php
+++ b/tests/Unit/Support/Constraint/IsEquivalentCssTest.php
@@ -21,9 +21,6 @@ final class IsEquivalentCssTest extends TestCase
     /**
      * @test
      *
-     * @param string $css
-     * @param string $otherCss
-     *
      * @dataProvider provideEquivalentCss
      */
     public function matchesEquivalentCss(string $css, string $otherCss): void
@@ -37,9 +34,6 @@ final class IsEquivalentCssTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $css
-     * @param string $otherCss
      *
      * @dataProvider provideNonEquivalentCss
      */
@@ -67,9 +61,6 @@ final class IsEquivalentCssTest extends TestCase
         return $datasets + $transposedDatasets;
     }
 
-    /**
-     * @return Constraint
-     */
     protected function createSubject(): Constraint
     {
         return new IsEquivalentCss('');

--- a/tests/Unit/Support/Constraint/StringContainsCssCountTest.php
+++ b/tests/Unit/Support/Constraint/StringContainsCssCountTest.php
@@ -21,9 +21,6 @@ final class StringContainsCssCountTest extends TestCase
     /**
      * @test
      *
-     * @param string $needle
-     * @param string $haystack
-     *
      * @dataProvider provideCssNeedleNotFoundInHaystack
      */
     public function matchesHaystackNotContainingNeedleWithZeroCount(string $needle, string $haystack): void
@@ -37,9 +34,6 @@ final class StringContainsCssCountTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $needle
-     * @param string $haystack
      *
      * @dataProvider provideEquivalentCss
      * @dataProvider provideEquivalentCssInStyleTags
@@ -57,9 +51,6 @@ final class StringContainsCssCountTest extends TestCase
     /**
      * @test
      *
-     * @param string $needle
-     * @param string $haystack
-     *
      * @dataProvider provideEquivalentCss
      * @dataProvider provideEquivalentCssInStyleTags
      * @dataProvider provideCssNeedleFoundInLargerHaystack
@@ -76,9 +67,6 @@ final class StringContainsCssCountTest extends TestCase
     /**
      * @test
      *
-     * @param string $needle
-     * @param string $haystack
-     *
      * @dataProvider provideCssNeedleNotFoundInHaystack
      */
     public function notMatchesHaystackNotContainingNeedleWithCountOfOne(string $needle, string $haystack): void
@@ -92,9 +80,6 @@ final class StringContainsCssCountTest extends TestCase
 
     /**
      * @test
-     *
-     * @param string $needle
-     * @param string $haystack
      *
      * @dataProvider provideEquivalentCss
      * @dataProvider provideEquivalentCssInStyleTags
@@ -112,9 +97,6 @@ final class StringContainsCssCountTest extends TestCase
     /**
      * @test
      *
-     * @param string $needle
-     * @param string $haystack
-     *
      * @dataProvider provideEquivalentCss
      * @dataProvider provideEquivalentCssInStyleTags
      * @dataProvider provideCssNeedleFoundInLargerHaystack
@@ -131,9 +113,6 @@ final class StringContainsCssCountTest extends TestCase
     /**
      * @test
      *
-     * @param string $needle
-     * @param string $haystack
-     *
      * @dataProvider provideCssNeedleNotFoundInHaystack
      */
     public function notMatchesHaystackNotContainingNeedleWithCountOfTwo(string $needle, string $haystack): void
@@ -148,9 +127,6 @@ final class StringContainsCssCountTest extends TestCase
     /**
      * @test
      *
-     * @param string $needle
-     * @param string $haystack
-     *
      * @dataProvider provideEquivalentCss
      * @dataProvider provideEquivalentCssInStyleTags
      * @dataProvider provideCssNeedleFoundInLargerHaystack
@@ -164,9 +140,6 @@ final class StringContainsCssCountTest extends TestCase
         self::assertFalse($result);
     }
 
-    /**
-     * @return Constraint
-     */
     protected function createSubject(): Constraint
     {
         return new StringContainsCssCount(0, '');

--- a/tests/Unit/Support/Constraint/StringContainsCssTest.php
+++ b/tests/Unit/Support/Constraint/StringContainsCssTest.php
@@ -21,9 +21,6 @@ final class StringContainsCssTest extends TestCase
     /**
      * @test
      *
-     * @param string $needle
-     * @param string $haystack
-     *
      * @dataProvider provideEquivalentCss
      * @dataProvider provideEquivalentCssInStyleTags
      * @dataProvider provideCssNeedleFoundInLargerHaystack
@@ -40,9 +37,6 @@ final class StringContainsCssTest extends TestCase
     /**
      * @test
      *
-     * @param string $needle
-     * @param string $haystack
-     *
      * @dataProvider provideCssNeedleNotFoundInHaystack
      */
     public function notMatchesHaystackNotContainingNeedle(string $needle, string $haystack): void
@@ -54,9 +48,6 @@ final class StringContainsCssTest extends TestCase
         self::assertFalse($result);
     }
 
-    /**
-     * @return Constraint
-     */
     protected function createSubject(): Constraint
     {
         return new StringContainsCss('');

--- a/tests/Unit/Utilities/CssConcatenatorTest.php
+++ b/tests/Unit/Utilities/CssConcatenatorTest.php
@@ -287,10 +287,7 @@ final class CssConcatenatorTest extends TestCase
      * @test
      *
      * @param string[] $rule1Selectors
-     * @param string $rule1DeclarationsBlock
      * @param string[] $rule2Selectors
-     * @param string $rule2DeclarationsBlock
-     * @param string $media
      *
      * @dataProvider combinableRulesDataProvider
      */


### PR DESCRIPTION
Drop type annotations the are redundant to the native type
declarations.