### PR TITLE
[DEVELOPER] Disallow 'heredoc' and 'nowdoc' for strings

### DIFF
--- a/config/phpcs.xml
+++ b/config/phpcs.xml
@@ -9,4 +9,5 @@
       <property name="absoluteLineLimit" value="120"/>
     </properties>
   </rule>
+  <rule ref="Squiz.PHP.Heredoc"/>
 </ruleset>


### PR DESCRIPTION
Counterpart of https://github.com/MyIntervals/PHP-CSS-Parser/pull/1415.