### PR TITLE
[TASK] Add test for `CssVariableEvaluator` with deeply-nested HTML

### DIFF
--- a/tests/Unit/HtmlProcessor/CssVariableEvaluatorTest.php
+++ b/tests/Unit/HtmlProcessor/CssVariableEvaluatorTest.php
@@ -390,4 +390,34 @@ final class CssVariableEvaluatorTest extends TestCase
 
         self::assertStringContainsString($expectedHtmlFragment, $htmlResult);
     }
+
+    /**
+     * @return array<string, array{0: positive-int}>
+     */
+    public function provideNestingLevel(): array
+    {
+        return [
+            '12 deep' => [12],
+            '257 deep' => [257],
+            '513 deep' => [513],
+            '1300 deep' => [1300],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param positive-int $nestingLevel
+     *
+     * @dataProvider provideNestingLevel
+     */
+    public function supportsDeeplyNestedHtml(int $nestingLevel): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $html = \str_repeat('<div>', $nestingLevel) . \str_repeat('</div>', $nestingLevel);
+        $subject = CssVariableEvaluator::fromHtml($html);
+
+        $subject->evaluateVariables();
+    }
 }


### PR DESCRIPTION
Relates to #1555.

The test currently passes without the Xdebug extension, but fails with it, unless `xdebug.max_nesting_level` is set sufficiently high in `php.ini`.

The error message is "Error: Xdebug has detected a possible infinite loop, and aborted your script with a stack depth of '512' frames"