### PR TITLE
[BUGFIX] Avoid recursive method call in `CssVariableEvaluator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please also have a look at our
 
 ### Fixed
 
-- Allow very deeply-nested HTML (#1556)
+- Allow very deeply-nested HTML (#1556, #1560)
 
 ## 8.2.0: Add support for Symfony 8.0
 

--- a/tests/Unit/HtmlProcessor/CssVariableEvaluatorTest.php
+++ b/tests/Unit/HtmlProcessor/CssVariableEvaluatorTest.php
@@ -399,9 +399,8 @@ final class CssVariableEvaluatorTest extends TestCase
         return [
             '12 deep' => [12],
             '257 deep' => [257],
-            // Temporarily disabled pending fix for #1555
-            //'513 deep' => [513],
-            //'1300 deep' => [1300],
+            '513 deep' => [513],
+            '1300 deep' => [1300],
         ];
     }
 


### PR DESCRIPTION
Fixes #1555.

This avoids creating a large call stack with deeply-nested HTML, and may be a slight optimization, certainly in terms of memory usage.

Now that the implementation does not use recursion, a separate private method is no longer needed.