### PR TITLE
[CLEANUP] Tighten some types in `CssConstraint`

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -89,9 +89,3 @@ parameters:
 			identifier: assign.propertyReadOnly
 			count: 1
 			path: ../src/Utilities/CssConcatenator.php
-
-		-
-			message: '#^Cannot cast mixed to int\.$#'
-			identifier: cast.int
-			count: 1
-			path: ../tests/Support/Constraint/CssConstraint.php

--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -179,7 +179,10 @@ abstract class CssConstraint extends Constraint
 
         $pattern = '/\\$(\\d++)/';
         $callback = static function (array $referenceMatches) use ($matches): string {
-            return \preg_quote($matches[(int) $referenceMatches[1]] ?? '', '/');
+            $index = $referenceMatches[1];
+            \assert(\is_string($index));
+
+            return \preg_quote($matches[$index] ?? '', '/');
         };
         foreach (self::CSS_REGULAR_EXPRESSION_REPLACEMENTS as $index => $replacement) {
             if (($matches[$index] ?? '') !== '') {


### PR DESCRIPTION
In PHP, int-like string keys don't need to be int-cast to work as array keys: PHP will auto-convert those strings to ints.