### PR TITLE
[CLEANUP] Replace a condition with an assertion

### DIFF
--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -115,10 +115,7 @@ abstract class AbstractHtmlProcessor
      */
     public function getDomDocument(): \DOMDocument
     {
-        if (!$this->domDocument instanceof \DOMDocument) {
-            $message = self::class . '::setDomDocument() has not yet been called on ' . static::class;
-            throw new \UnexpectedValueException($message, 1570472239);
-        }
+        \assert($this->domDocument instanceof \DOMDocument);
 
         return $this->domDocument;
     }


### PR DESCRIPTION
The way we construct HTML processors, this exception will never be thrown. As PHPStan does not know this, state this knowledge using an assertion.