### PR TITLE
[TASK] Deprecate support for PHP 7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Please also have a look at our
 
 ### Deprecated
 
+- Deprecate support for PHP 7.3 (#1604)
+
 ### Removed
 
 ### Fixed


### PR DESCRIPTION
WordPress 7.0 will drop support for PHP 7.2 and 7.3 [1], and PHP 7.3 was EOLed in December 2021. [2]

So it's time to deprecate support for PHP < 7.4, allowing us to make use of features like native types for properties, as discussed. [3]

[1] https://make.wordpress.org/core/2026/01/09/dropping-support-for-php-7-2-and-7-3/
[2] https://www.php.net/eol.php
[3] https://github.com/MyIntervals/PHP-CSS-Parser/discussions/1563