### PR TITLE
[BUGFIX] Add missing `export-ignore` in `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 /.github/ export-ignore
 /.gitignore export-ignore
 /.phive/ export-ignore
-/Build/
+/Build/ export-ignore
 /CODE_OF_CONDUCT.md export-ignore
 /CONTRIBUTING.md export-ignore
 /config/ export-ignore


### PR DESCRIPTION
Followup to #1606