### PR TITLE
[TASK] Also check `Build/` with static code analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,9 +93,9 @@
         "check:dynamic": [
             "@check:tests"
         ],
-        "check:php:codesniffer": "phpcs --standard=./Build/phpcs/config.xml config src tests",
-        "check:php:fixer": "\"./.phive/php-cs-fixer\" --config=./Build/php-cs-fixer/config.php fix --dry-run -v --show-progress=dots config src tests",
-        "check:php:lint": "parallel-lint config src tests",
+        "check:php:codesniffer": "phpcs --standard=./Build/phpcs/config.xml Build config src tests",
+        "check:php:fixer": "\"./.phive/php-cs-fixer\" --config=./Build/php-cs-fixer/config.php fix --dry-run -v --show-progress=dots Build config src tests",
+        "check:php:lint": "parallel-lint Build config src tests",
         "check:php:md": "phpmd src text config/phpmd.xml",
         "check:php:rector": "rector process --no-progress-bar --dry-run --config=config/rector.php",
         "check:php:stan": "phpstan --no-progress --configuration=./Build/phpstan/phpstan.neon",

--- a/config/rector.php
+++ b/config/rector.php
@@ -10,6 +10,7 @@ use Rector\Set\ValueObject\SetList;
 return RectorConfig::configure()
     ->withPaths(
         [
+            __DIR__ . '/../Build',
             __DIR__ . '/../config',
             __DIR__ . '/../src',
             __DIR__ . '/../tests',


### PR DESCRIPTION
We now have PHP files in `Build/`, and we should check and autofix those as well.

We omit these two tools:

- PHPStan (as it cannot find the PHP-CS-Fixer classes from the PHAR)
- PHPMD (as it only can check one directory)