### PR TITLE
[CLEANUP] Rely on PHP to detect access to uninitialized properties

### DIFF
--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -417,7 +417,7 @@ final class CssInliner extends AbstractHtmlProcessor
     private function getAllNodesWithStyleAttribute(): \DOMNodeList
     {
         $query = '//*[@style]';
-        $matches = $this->getXPath()->query($query);
+        $matches = $this->xPath->query($query);
         \assert($matches instanceof \DOMNodeList);
         /** @var \DOMNodeList<\DOMElement> $matches */
 
@@ -467,7 +467,7 @@ final class CssInliner extends AbstractHtmlProcessor
      */
     private function getCssFromAllStyleNodes(): string
     {
-        $styleNodes = $this->getXPath()->query('//style');
+        $styleNodes = $this->xPath->query('//style');
         if ($styleNodes === false) {
             return '';
         }
@@ -518,7 +518,7 @@ final class CssInliner extends AbstractHtmlProcessor
     private function querySelectorAll(string $selectors, array $options = []): \DOMNodeList
     {
         try {
-            $result = $this->getXPath()->query($this->getCssSelectorConverter()->toXPath($selectors));
+            $result = $this->xPath->query($this->getCssSelectorConverter()->toXPath($selectors));
             \assert($result instanceof \DOMNodeList);
         } catch (ParseException $exception) {
             $alwaysThrowParseException = $options[self::QSA_ALWAYS_THROW_PARSE_EXCEPTION] ?? false;

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -78,6 +78,7 @@ abstract class AbstractHtmlProcessor
 
         $instance = new static();
         $instance->setHtml($unprocessedHtml);
+        \assert($instance->xPath instanceof \DOMXPath);
 
         return $instance;
     }
@@ -93,6 +94,7 @@ abstract class AbstractHtmlProcessor
     {
         $instance = new static();
         $instance->setDomDocument($document);
+        \assert($instance->xPath instanceof \DOMXPath);
 
         return $instance;
     }
@@ -109,8 +111,6 @@ abstract class AbstractHtmlProcessor
 
     /**
      * Provides access to the internal DOMDocument representation of the HTML in its current state.
-     *
-     * @throws \UnexpectedValueException
      */
     public function getDomDocument(): \DOMDocument
     {

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -50,9 +50,9 @@ abstract class AbstractHtmlProcessor
     private $domDocument;
 
     /**
-     * @var \DOMXPath|null
+     * @var \DOMXPath
      */
-    private $xPath = null;
+    protected $xPath;
 
     /**
      * The constructor.
@@ -121,19 +121,6 @@ abstract class AbstractHtmlProcessor
     {
         $this->domDocument = $domDocument;
         $this->xPath = new \DOMXPath($domDocument);
-    }
-
-    /**
-     * @throws \UnexpectedValueException
-     */
-    protected function getXPath(): \DOMXPath
-    {
-        if (!$this->xPath instanceof \DOMXPath) {
-            $message = self::class . '::setDomDocument() has not yet been called on ' . static::class;
-            throw new \UnexpectedValueException($message, 1617819086);
-        }
-
-        return $this->xPath;
     }
 
     /**

--- a/src/HtmlProcessor/CssToAttributeConverter.php
+++ b/src/HtmlProcessor/CssToAttributeConverter.php
@@ -77,7 +77,7 @@ final class CssToAttributeConverter extends AbstractHtmlProcessor
      */
     private function getAllNodesWithStyleAttribute(): \DOMNodeList
     {
-        $result = $this->getXPath()->query('//*[@style]');
+        $result = $this->xPath->query('//*[@style]');
         \assert($result instanceof \DOMNodeList);
         /** @var \DOMNodeList<\DOMElement> $result */
 

--- a/src/HtmlProcessor/HtmlPruner.php
+++ b/src/HtmlProcessor/HtmlPruner.php
@@ -32,7 +32,7 @@ final class HtmlPruner extends AbstractHtmlProcessor
      */
     public function removeElementsWithDisplayNone(): self
     {
-        $elementsWithStyleDisplayNone = $this->getXPath()->query(self::DISPLAY_NONE_MATCHER);
+        $elementsWithStyleDisplayNone = $this->xPath->query(self::DISPLAY_NONE_MATCHER);
         \assert($elementsWithStyleDisplayNone instanceof \DOMNodeList);
         if ($elementsWithStyleDisplayNone->length === 0) {
             return $this;
@@ -65,7 +65,7 @@ final class HtmlPruner extends AbstractHtmlProcessor
     public function removeRedundantClasses(array $classesToKeep = []): self
     {
         /** @var \DOMNodeList<\DOMElement> $elementsWithClassAttribute */
-        $elementsWithClassAttribute = $this->getXPath()->query('//*[@class]');
+        $elementsWithClassAttribute = $this->xPath->query('//*[@class]');
 
         if ($classesToKeep !== []) {
             $this->removeClassesFromElements($elementsWithClassAttribute, $classesToKeep);


### PR DESCRIPTION
In our code, this exception that indicated that the property was access before initialization is never thrown.

So we can simplify our code by removing the check (and the exception) and make use of PHP's own mechanism for throwing an error if the property is accessed before initialization.