### PR TITLE
[TASK] Do not treat PHPDoc type information as certain

### DIFF
--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -10,6 +10,8 @@ parameters:
     - %currentWorkingDirectory%/src/
     - %currentWorkingDirectory%/tests/
 
+  treatPhpDocTypesAsCertain: false
+
   type_perfect:
     no_mixed_property: true
     no_mixed_caller: true

--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -72,7 +72,6 @@ abstract class AbstractHtmlProcessor
      */
     public static function fromHtml(string $unprocessedHtml): self
     {
-        // @phpstan-ignore-next-line argument.type We're checking for a contract violation here.
         if ($unprocessedHtml === '') {
             throw new \InvalidArgumentException('The provided HTML must not be empty.', 1515763647);
         }


### PR DESCRIPTION
This is a library. This means that we have no control over how other software calls our methods, and whether they adher to the types required via `@param` annotations.

Hence, we shouldn't rely on those types being certain.