### PR TITLE
[TASK] `assert()` that `HtmlProcessor::domDocument` is initialized

### DIFF
--- a/src/HtmlProcessor/AbstractHtmlProcessor.php
+++ b/src/HtmlProcessor/AbstractHtmlProcessor.php
@@ -78,6 +78,7 @@ abstract class AbstractHtmlProcessor
 
         $instance = new static();
         $instance->setHtml($unprocessedHtml);
+        \assert($instance->domDocument instanceof \DOMDocument);
         \assert($instance->xPath instanceof \DOMXPath);
 
         return $instance;
@@ -94,6 +95,7 @@ abstract class AbstractHtmlProcessor
     {
         $instance = new static();
         $instance->setDomDocument($document);
+        \assert($instance->domDocument instanceof \DOMDocument);
         \assert($instance->xPath instanceof \DOMXPath);
 
         return $instance;
@@ -114,6 +116,8 @@ abstract class AbstractHtmlProcessor
      */
     public function getDomDocument(): \DOMDocument
     {
+        \assert($this->domDocument instanceof \DOMDocument);
+
         return $this->domDocument;
     }
 


### PR DESCRIPTION
Following #1622, we can add the `assert()`s that were considered for #1621.

These will help quickly pinpoint mistakes during development, and have no significant impact on production environments (the extra code will have to be parsed, but once it's in the opcache, there'll be no performance hit).