### PR TITLE
[BUGFIX] Use `@phpstan-ignore` not `@phpstan-ignore-next-line`

### DIFF
--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -434,7 +434,8 @@ final class CssInliner extends AbstractHtmlProcessor
         if (\function_exists('Safe\\preg_replace_callback')) {
             $normalizedOriginalStyle = preg_replace_callback($pattern, $callback, $node->getAttribute('style'));
         } else {
-            // @phpstan-ignore-next-line The safe version is only available in "thecodingmachine/safe" for PHP >= 8.1.
+            // The safe version is only available in "thecodingmachine/safe" for PHP >= 8.1.
+            // @phpstan-ignore theCodingMachineSafe.function
             $normalizedOriginalStyle = \preg_replace_callback($pattern, $callback, $node->getAttribute('style'));
             \assert(\is_string($normalizedOriginalStyle));
         }
@@ -971,7 +972,8 @@ final class CssInliner extends AbstractHtmlProcessor
         if (\function_exists('Safe\\preg_replace_callback')) {
             $untrimmedSelectorWithoutNots = preg_replace_callback($pattern, $callback, ' ' . $selector);
         } else {
-            // @phpstan-ignore-next-line The safe version is only available in "thecodingmachine/safe" for PHP >= 8.1.
+            // The safe version is only available in "thecodingmachine/safe" for PHP >= 8.1.
+            // @phpstan-ignore theCodingMachineSafe.function
             $untrimmedSelectorWithoutNots = \preg_replace_callback($pattern, $callback, ' ' . $selector);
             \assert(\is_string($untrimmedSelectorWithoutNots));
         }

--- a/src/HtmlProcessor/CssVariableEvaluator.php
+++ b/src/HtmlProcessor/CssVariableEvaluator.php
@@ -166,7 +166,8 @@ final class CssVariableEvaluator extends AbstractHtmlProcessor
         if (\function_exists('Safe\\preg_replace_callback')) {
             $result = preg_replace_callback($pattern, $callable, $propertyValue);
         } else {
-            // @phpstan-ignore-next-line The safe version is only available in "thecodingmachine/safe" for PHP >= 8.1.
+            // The safe version is only available in "thecodingmachine/safe" for PHP >= 8.1.
+            // @phpstan-ignore theCodingMachineSafe.function
             $result = \preg_replace_callback($pattern, $callable, $propertyValue);
         }
         \assert(\is_string($result));

--- a/tests/Support/Constraint/CssConstraint.php
+++ b/tests/Support/Constraint/CssConstraint.php
@@ -168,7 +168,8 @@ abstract class CssConstraint extends Constraint
         if (\function_exists('Safe\\preg_replace_callback')) {
             $matcher = preg_replace_callback(self::CSS_REGULAR_EXPRESSION_PATTERN, $callback, $css);
         } else {
-            // @phpstan-ignore-next-line The safe version is only available in "thecodingmachine/safe" for PHP >= 8.1.
+            // The safe version is only available in "thecodingmachine/safe" for PHP >= 8.1.
+            // @phpstan-ignore theCodingMachineSafe.function
             $matcher = \preg_replace_callback(self::CSS_REGULAR_EXPRESSION_PATTERN, $callback, $css);
         }
         \assert(\is_string($matcher));
@@ -197,7 +198,8 @@ abstract class CssConstraint extends Constraint
                 if (\function_exists('Safe\\preg_replace_callback')) {
                     $regularExpressionEquivalent = preg_replace_callback($pattern, $callback, $replacement);
                 } else {
-                    // @phpstan-ignore-next-line The safe version in "thecodingmachine/safe" needs PHP >= 8.1.
+                    // The safe version is only available in "thecodingmachine/safe" for PHP >= 8.1.
+                    // @phpstan-ignore theCodingMachineSafe.function
                     $regularExpressionEquivalent = \preg_replace_callback($pattern, $callback, $replacement);
                 }
                 \assert(\is_string($regularExpressionEquivalent));

--- a/tests/Unit/Caching/SimpleStringCacheTest.php
+++ b/tests/Unit/Caching/SimpleStringCacheTest.php
@@ -31,7 +31,7 @@ final class SimpleStringCacheTest extends TestCase
         $this->expectExceptionCode(1625995840);
         $this->expectExceptionMessage('Please provide a non-empty key.');
 
-        // @phpstan-ignore-next-line argument.type We're explicitly testing with an invalid value here.
+        // @phpstan-ignore argument.type (We're explicitly testing with an invalid value here.)
         $this->subject->has('');
     }
 
@@ -85,7 +85,7 @@ final class SimpleStringCacheTest extends TestCase
         $this->expectExceptionCode(1625995840);
         $this->expectExceptionMessage('Please provide a non-empty key.');
 
-        // @phpstan-ignore-next-line argument.type We're explicitly testing with an invalid value here.
+        // @phpstan-ignore argument.type (We're explicitly testing with an invalid value here.)
         $this->subject->get('');
     }
 
@@ -98,7 +98,7 @@ final class SimpleStringCacheTest extends TestCase
         $this->expectExceptionCode(1625995840);
         $this->expectExceptionMessage('Please provide a non-empty key.');
 
-        // @phpstan-ignore-next-line argument.type We're explicitly testing with an invalid value here.
+        // @phpstan-ignore argument.type (We're explicitly testing with an invalid value here.)
         $this->subject->set('', 'some value');
     }
 

--- a/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
+++ b/tests/Unit/HtmlProcessor/AbstractHtmlProcessorTest.php
@@ -151,7 +151,7 @@ final class AbstractHtmlProcessorTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        // @phpstan-ignore-next-line argument.type We're explicitly testing with an invalid value here.
+        // @phpstan-ignore argument.type (We're explicitly testing with an invalid value here.)
         TestingHtmlProcessor::fromHtml('');
     }
 


### PR DESCRIPTION
`@phpstan-ignore` has the parameter which is the specific warning to ignore. `@phpstan-ignore-next-line` does not, and will result in suppression of all warnings for the next line.
`@phpstan-ignore` also only applies to the next line (or whatever is relevent in context).