### PR TITLE
[BUGFIX] Add missing `use` in PHPStan extension test

### DIFF
--- a/tests/Unit/PhpStan/IgnoreBooleanAlwaysImpossibleInstanceofTest.php
+++ b/tests/Unit/PhpStan/IgnoreBooleanAlwaysImpossibleInstanceofTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pelago\Emogrifier\Tests\Unit\PhpStan;
 
+use PHPStan\Analyser\IgnoreErrorExtension;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Rules\Classes\ImpossibleInstanceOfRule;
 use PHPStan\Rules\Rule;


### PR DESCRIPTION
PHPStan is only run on a recent PHP version, so the extension only needs testing against that version.  Older versions of PHPStan (which support older PHP versions) do not support the extension.  But the unit tests are run on all supported PHP versions, so those for the extension need to be skipped on versions for which it is not supported.  This is done via an `interface_exists()` check.

But without the `use` statement, that check was resulting in the test being skipped for all versions.